### PR TITLE
Add PET repo as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = runtimes
 	url = git@github.com:polkadot-fellows/runtimes.git
 	branch = dev-asset-hub-migration
+[submodule "polkadot-ecosystem-tests"]
+	path = polkadot-ecosystem-tests
+	url = git@github.com:open-web3-stack/polkadot-ecosystem-tests.git
+	branch = ahm-tests


### PR DESCRIPTION
https://github.com/open-web3-stack/polkadot-ecosystem-tests is added, in this PR, as a submodule, using the `ahm-tests` branch.
This branch replicates the already existing Polkadot/Kusama E2E tests on the Asset Hub chain.

I plan to keep `ahm-tests` up-to-date with `master` by rebasing the tip with the above-mentioned additions.