### PR TITLE
Added a command to spin up a polkadot RC node

### DIFF
--- a/justfile
+++ b/justfile
@@ -8,6 +8,10 @@ default:
 run:
     npx @acala-network/chopsticks@latest xcm -r ./configs/polkadot.yml -p ./configs/polkadot-asset-hub.yml -p ./configs/polkadot-collectives.yml
 
+# Spins up and sync polkadot node
+sync:
+    polkadot --sync warp --rpc-max-request-size 999999999 --rpc-max-response-size 999999999 --state-pruning 1000 --blocks-pruning 1000 --tmp --rpc-port 9944 --rpc-cors all
+
 # Run the network from the pre-migration state
 run-pre:
     POLKADOT_BLOCK_NUMBER=${POLKADOT_BLOCK_NUMBER_PRE} POLKADOT_ASSET_HUB_BLOCK_NUMBER=${POLKADOT_ASSET_HUB_BLOCK_NUMBER_PRE} POLKADOT_COLLECTIVES_BLOCK_NUMBER=${POLKADOT_COLLECTIVES_BLOCK_NUMBER_PRE} npx @acala-network/chopsticks@latest xcm -r ./configs/polkadot.yml -p ./configs/polkadot-asset-hub.yml -p ./configs/polkadot-collectives.yml


### PR DESCRIPTION
Adding asset-hub and other para/system-chains is a bit more complex and requires adding polkadot cumulus submodule. 
We might not want to do that at all, because we'll take advantage of injecting raw sqlite dbs into the repository and won't be syncing it manually as part of CI/CD. 

Just for completeness here is the instruction to spin up AH parachain: 
- build polkadot-parachain binary executable using `cargo build --release --bin polkadot-parachain`
- cd into `taget/release` folder
- run
```
./polkadot-parachain --chain asset-hub-polkadot --name "first AH node" --sync warp --rpc-max-request-size 999999999 --rpc-max-response-size 999999999 --tmp --rpc-port 9955 --rpc-cors all
```