### PR TITLE
Add ahm westend as submodule

### DIFF
--- a/.env
+++ b/.env
@@ -12,9 +12,7 @@ POLKADOT_COLLECTIVES_BLOCK_NUMBER_PRE=
 # Just take care with the hash that you have checked out
 RUNTIMES_PATH=./runtimes
 PET_PATH=./polkadot-ecosystem-tests
-
-# This will soon be a submodule
-SDK_PATH=../polkadot-sdk
+SDK_PATH=./polkadot-sdk
 
 # Local relay and AH node ports to speed up snapshot creation
 RELAY_NODE_RPC_PORT=9944
@@ -25,8 +23,10 @@ POLKADOT_RPC=ws://localhost
 
 # Local
 CARGO_CMD=cargo
-BUILD_ARTIFACTS_PATH=./runtimes/target/release/wbuild
+RUNTIMES_BUILD_ARTIFACTS_PATH=$RUNTIMES_PATH/target/release/
+SDK_BUILD_ARTIFACTS_PATH=$SDK_PATH/target/release/
 
 # Remote server
 # CARGO_CMD=cargo remote --
-# BUILD_ARTIFACTS_PATH=palace-frame:remote-builds/runtimes/target/release/wbuild
+# RUNTIMES_BUILD_ARTIFACTS_PATH=palace-frame:remote-builds/runtimes/target/release/
+# SDK_BUILD_ARTIFACTS_PATH=palace-frame:remote-builds/polkadot-sdk/target/release/

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,7 @@
 	path = polkadot-ecosystem-tests
 	url = git@github.com:open-web3-stack/polkadot-ecosystem-tests.git
 	branch = ahm-tests
+[submodule "polkadot-sdk"]
+	path = polkadot-sdk
+	url = git@github.com:paritytech/polkadot-sdk.git
+	branch = donal-ahm

--- a/configs/polkadot-asset-hub.yml
+++ b/configs/polkadot-asset-hub.yml
@@ -1,18 +1,7 @@
-endpoint: wss://polkadot-asset-hub-rpc.polkadot.io
+endpoint: ${env.POLKADOT_RPC}:${env.AH_NODE_RPC_PORT}
 mock-signature-host: true
-block: ${env.POLKADOT_ASSET_HUB_BLOCK_NUMBER}
 db: ./dbs/polkadot-asset-hub.sqlite
 runtime-log-level: 5
 
 wasm-override: ./runtime_wasm/asset_hub_polkadot_runtime.compact.compressed.wasm
 # resume: true
-
-import-storage:
-  System:
-    Account:
-      - [[5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY], { providers: 1, data: { free: 1000000000000000 }}]
-  Assets:
-    Account:
-      - [[1984, 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY], { balance: 1000000000 }]
-    Asset: [[[1984], { supply: 1000000000 }]]
-

--- a/configs/polkadot.yml
+++ b/configs/polkadot.yml
@@ -1,17 +1,7 @@
-endpoint:
-  - wss://rpc.ibp.network/polkadot
-  - wss://polkadot-rpc.dwellir.com
+endpoint: ${env.POLKADOT_RPC}:${env.RELAY_NODE_RPC_PORT}
 mock-signature-host: true
-block: ${env.POLKADOT_BLOCK_NUMBER}
 db: ./dbs/polkadot.sqlite
 runtime-log-level: 5
 
 wasm-override: ./runtime_wasm/polkadot_runtime.compact.compressed.wasm
 # resume: true
-
-import-storage:
-  System:
-    Account:
-      - [[5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY], { providers: 1, data: { free: 1000000000000000 }}]
-  ParasDisputes:
-    $removePrefix: ['disputes'] # those can makes block building super slow


### PR DESCRIPTION
The asset hub migration for westend is being prepared in https://github.com/paritytech/polkadot-sdk/pull/7997

Add it here as a submodule so we can start preparing the e2e tests and dry runs for it.