### PR TITLE
add submodule and readme to run zombie-bite

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,7 @@
 	path = polkadot-sdk
 	url = git@github.com:paritytech/polkadot-sdk.git
 	branch = donal-ahm
+[submodule "zombie-bite/polkadot-sdk-doppelganger"]
+	path = zombie-bite/polkadot-sdk-doppelganger
+	url = git@github.com:paritytech/polkadot-sdk.git
+	branch = jv-doppelganger-node

--- a/zombie-bite/README.md
+++ b/zombie-bite/README.md
@@ -1,0 +1,45 @@
+# Zombie-bite
+
+## Intro
+
+`zombie-bite` is an cli tool that allow you to _fork and spawn_ live networks (e.g polkadot/kusama) keeping the _live state_ with the needed customizations in order to make the new chain/s keep progressing.
+
+### Instruction to spawn Polkadot(with sudo)/AH
+
+ - Install `zombie-bite`
+
+   ```
+   cargo install --git https://github.com/pepoviola/zombie-bite --bin zombie-bite
+   ```
+
+- Patch and compile polkadot runtime to add sudo
+
+Apply the patch `polkadot_sudo.patch` on top of the polkadot code in `runtimes` directory and then compile the runtime.
+
+```
+cd ../runtimes && cargo build --release -p polkadot-runtime && cd -
+```
+
+- Compile the needed binaries (from `polkadot-sdk-doppelganger`)
+
+```
+cd polkadot-sdk-doppelganger
+SKIP_WASM_BUILD=1 cargo build --release -p polkadot-doppelganger-node --bin doppelganger
+SKIP_WASM_BUILD=1 cargo build --release -p polkadot-parachain-bin --features doppelganger --bin doppelganger-parachain
+SKIP_WASM_BUILD=1 cargo build --release -p polkadot-parachain-bin --bin polkadot-parachain
+SKIP_WASM_BUILD=1 cargo build --release --bin polkadot --bin polkadot-prepare-worker --bin polkadot-execute-worker
+```
+
+- Make them available in your `PATH`
+
+ ```
+ export PATH=$(pwd)/target/release:$PATH
+ ```
+
+- Run `zombie-bite`
+
+```
+zombie-bite polkadot:<path_to_polkadot_wasm> asset-hub
+```
+
+You should get a new network with the `live state` running locally.

--- a/zombie-bite/polkadot_sudo.patch
+++ b/zombie-bite/polkadot_sudo.patch
@@ -1,0 +1,88 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 768e9d8a8..9f81c65ff 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -10256,6 +10256,7 @@ dependencies = [
+  "pallet-staking-reward-fn",
+  "pallet-staking-runtime-api",
+  "pallet-state-trie-migration",
++ "pallet-sudo",
+  "pallet-timestamp",
+  "pallet-transaction-payment",
+  "pallet-transaction-payment-rpc-runtime-api",
+diff --git a/relay/polkadot/Cargo.toml b/relay/polkadot/Cargo.toml
+index 5176168fb..cfdc8858d 100644
+--- a/relay/polkadot/Cargo.toml
++++ b/relay/polkadot/Cargo.toml
+@@ -115,6 +115,9 @@ sp-debug-derive = { workspace = true }
+ # just for the coretime migration
+ polkadot-parachain-primitives = { workspace = true }
+ 
++# SUDO
++pallet-sudo = { workspace = true }
++
+ [dev-dependencies]
+ approx = { workspace = true }
+ sp-keyring = { workspace = true }
+@@ -188,6 +191,8 @@ std = [
+ 	"pallet-staking-runtime-api/std",
+ 	"pallet-staking/std",
+ 	"pallet-state-trie-migration/std",
++	# SUDO
++	"pallet-sudo/std",
+ 	"pallet-timestamp/std",
+ 	"pallet-transaction-payment-rpc-runtime-api/std",
+ 	"pallet-transaction-payment/std",
+diff --git a/relay/polkadot/src/ah_migration/phase1.rs b/relay/polkadot/src/ah_migration/phase1.rs
+index 221f68457..220dadbf7 100644
+--- a/relay/polkadot/src/ah_migration/phase1.rs
++++ b/relay/polkadot/src/ah_migration/phase1.rs
+@@ -134,6 +134,7 @@ pub fn call_allowed_status(call: &<Runtime as frame_system::Config>::RuntimeCall
+ 		AssetRate(..) => (OFF, OFF),
+ 		Beefy(..) => (OFF, ON), /* TODO @claravanstaden @bkontur */
+ 		RcMigrator(..) => (ON, ON),
++		Sudo(..) => (ON, ON)
+ 		// Exhaustive match. Compiler ensures that we did not miss any.
+ 	}
+ }
+diff --git a/relay/polkadot/src/genesis_config_presets.rs b/relay/polkadot/src/genesis_config_presets.rs
+index 63717f69e..a47debfe6 100644
+--- a/relay/polkadot/src/genesis_config_presets.rs
++++ b/relay/polkadot/src/genesis_config_presets.rs
+@@ -189,6 +189,9 @@ fn polkadot_testnet_genesis(
+ 			"forceEra": Forcing::NotForcing,
+ 			"slashRewardFraction": Perbill::from_percent(10),
+ 		},
++		"sudo": {
++			"key": Some(_root_key),
++		},
+ 		"babe": {
+ 			"epochConfig": Some(BABE_GENESIS_EPOCH_CONFIG),
+ 		},
+diff --git a/relay/polkadot/src/lib.rs b/relay/polkadot/src/lib.rs
+index 0a5f2a56e..fb3ce5a83 100644
+--- a/relay/polkadot/src/lib.rs
++++ b/relay/polkadot/src/lib.rs
+@@ -1712,11 +1712,22 @@ construct_runtime! {
+ 		Mmr: pallet_mmr = 201,
+ 		BeefyMmrLeaf: pallet_beefy_mmr = 202,
+ 
++		// Sudo.
++		Sudo: pallet_sudo = 250,
++
+ 		// Relay Chain Migrator
+ 		RcMigrator: pallet_rc_migrator = 255,
++
++
+ 	}
+ }
+ 
++impl pallet_sudo::Config for Runtime {
++	type RuntimeEvent = RuntimeEvent;
++	type RuntimeCall = RuntimeCall;
++	type WeightInfo = ();
++}
++
+ /// The address format for describing accounts.
+ pub type Address = sp_runtime::MultiAddress<AccountId, ()>;
+ /// Block header type as expected by this runtime.


### PR DESCRIPTION
Hi @seadanda, this `pr` add a new submodule to make more easy to get `doppelganger` running through zombie-bite. Also, there is an small readme with the instructions to run overriding the relaychain runtime (overriding the parachain runtime is still in progress). The whole _spawning_ process can take 20/30mins but depends on your internet connection since we need to sync warp both the relaychain and AH, but ones you run one time you can stop and _reuse_ the same snapshot many times(I think we can schedule runs in CI and collect the snapshots) . If you want we can touch base on this subject tomorrow.

Thanks! 