### PR TITLE
Changed zombie-bite command to force fetch it

### DIFF
--- a/justfile
+++ b/justfile
@@ -56,7 +56,7 @@ build-westend:
 
 # Run zombie-bite to spawn polkadot(with sudo)/asset-hub
 run-zombie-bite:
-    which zombie-bite 2>&1 > /dev/null || cargo install --git https://github.com/pepoviola/zombie-bite --bin zombie-bite
+    which zombie-bite 2>&1 > /dev/null || cargo install --git https://github.com/pepoviola/zombie-bite --bin zombie-bite --force
 
     just build-polkadot "--features zombie-bite-sudo"
 

--- a/justfile
+++ b/justfile
@@ -56,7 +56,7 @@ build-westend:
 
 # Run zombie-bite to spawn polkadot(with sudo)/asset-hub
 run-zombie-bite:
-    which zombie-bite 2>&1 > /dev/null || cargo install --git https://github.com/pepoviola/zombie-bite --bin zombie-bite --force
+    cargo install --git https://github.com/pepoviola/zombie-bite --bin zombie-bite --force
 
     just build-polkadot "--features zombie-bite-sudo"
 


### PR DESCRIPTION
In case if there is a previous version of zombie-bite in the system it won't be overridden.
Ideally is to check the latest and the current version but for now this should work fine.