### PR TITLE
Improved typescript config, added fetchStorage to chopsticks script

### DIFF
--- a/chopsticks-scripts/run_migration.ts
+++ b/chopsticks-scripts/run_migration.ts
@@ -1,4 +1,6 @@
 import { setupNetworks } from "@acala-network/chopsticks-testing";
+import { fetchStorages } from '@acala-network/chopsticks/utils/fetch-storages'
+
 import * as dotenv from 'dotenv';
 
 dotenv.config();
@@ -31,6 +33,20 @@ const { polkadot, assetHub } = await setupNetworks({
         db: "./dbs/polkadot-asset-hub.sqlite",
         port: 8001,
     },
+});
+
+await fetchStorages({
+    block: process.env.POLKADOT_ASSET_HUB_BLOCK_NUMBER_PRE,
+    endpoint: process.env.POLKADOT_ASSET_HUB_ENDPOINT || `ws://localhost:${process.env.AH_NODE_RPC_PORT}`,
+    dbPath: "./dbs/polkadot-asset-hub.sqlite",
+    config: ['0x'],
+});
+
+await fetchStorages({
+    block: process.env.POLKADOT_BLOCK_NUMBER_PRE,
+    endpoint: process.env.POLKADOT_ENDPOINT || `ws://localhost:${process.env.RELAY_NODE_RPC_PORT}`,
+    dbPath: "./dbs/polkadot.sqlite",
+    config: ['0x'],
 });
 
 let rcAccBefore = (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
1. Used fetch-storages per [Bryan's suggestion](https://github.com/AcalaNetwork/chopsticks/issues/895#issuecomment-2746714954)


2. With previous module resolution the script was failing generating the following error: 

```
> ahm@1.0.0 build
> tsc

chopsticks-scripts/run_migration.ts:2:31 - error TS2307: Cannot find module '@acala-network/chopsticks/utils/fetch-storages' or its corresponding type declarations.
  There are types at '/Users/ndk/parity/ahm-dryrun/node_modules/@acala-network/chopsticks/dist/esm/utils/fetch-storages.d.ts', but this result could not be resolved under your current 'moduleResolution' setting. Consider updating to 'node16', 'nodenext', or 'bundler'.

2 import { fetchStorages } from '@acala-network/chopsticks/utils/fetch-storages'
                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error in chopsticks-scripts/run_migration.ts:2
```