### PR TITLE
[WIP] Westend related tooling

### DIFF
--- a/.env
+++ b/.env
@@ -43,3 +43,7 @@ ZOMBIE_BITE_RC_PORT=63168
 # CARGO_CMD=cargo remote --
 # RUNTIMES_BUILD_ARTIFACTS_PATH=palace-frame:remote-builds/runtimes/target/release/
 # SDK_BUILD_ARTIFACTS_PATH=palace-frame:remote-builds/polkadot-sdk/target/release/
+
+## just e2e-westend-post-migration
+ASSETHUBWESTEND_WASM=../runtime_wasm/asset_hub_westend_runtime.compact.compressed.wasm
+WESTEND_WASM=../runtime_wasm/westend_runtime.compact.compressed.wasm

--- a/.github/workflows/zombie-bite-common.yml
+++ b/.github/workflows/zombie-bite-common.yml
@@ -1,0 +1,57 @@
+name: Zombie Bite Common
+
+on:
+  workflow_call:
+    inputs:
+      network:
+        required: true
+        type: string
+      sudo-key:
+        required: false
+        type: string
+
+env:
+  ZOMBIE_BITE_CI_PATH: "/tmp/ci"
+
+jobs:
+  run_zombie_bite:
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/paritytech/ci-unified:bullseye-1.84.1-2025-01-28-v202502131220
+    timeout-minutes: 90
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: extractions/setup-just@v2
+      - name: zombie_bite
+        shell: bash
+        env:
+          RUSTFLAGS: "-A warnings"
+          SUDO: ${{ inputs.sudo-key }}
+        run: |
+          echo 'CARGO_CMD="forklift cargo"' >> .env
+          mkdir -p ${ZOMBIE_BITE_CI_PATH}
+
+          if [[ $SUDO != "" ]]; then
+            export ZOMBIE_SUDO=$SUDO
+          else
+            echo "no sudo key provided, using default '//Alice'"
+          fi
+
+          apt-get update && apt-get install -y lz4 rsync
+
+          just create-${{ inputs.network }}-pre-migration-snapshot
+
+      - name: read_rc_block
+        id: read_rc_block
+        run: |
+          RC_BLOCK=$(cat $ZOMBIE_BITE_CI_PATH/rc-info.txt)
+          echo "RC_BLOCK=$RC_BLOCK" >> $GITHUB_OUTPUT
+      - name: upload_artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.network }}-zombie-bite-rc_block_${{ steps.read_rc_block.outputs.RC_BLOCK }}-${{ github.sha }}
+          path: |
+            /tmp/ci/*

--- a/.github/workflows/zombie-bite.yml
+++ b/.github/workflows/zombie-bite.yml
@@ -1,4 +1,5 @@
 name: Zombie-bite
+
 on:
   workflow_dispatch:
     inputs:
@@ -15,46 +16,16 @@ concurrency:
 
 permissions: {}
 
-env:
-  ZOMBIE_BITE_CI_PATH: "/tmp/ci"
-
 jobs:
-  run_zombie-bite:
-    runs-on: parity-large
-    container:
-        image: docker.io/paritytech/ci-unified:bullseye-1.84.1-2025-01-28-v202502131220
-    timeout-minutes: 90
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - uses: extractions/setup-just@v2
-      - name: install_zombie-bite
-        run: |
-          cargo install --git https://github.com/pepoviola/zombie-bite --bin zombie-bite
-      - name: zombie_bite
-        shell: bash
-        env:
-          RUSTFLAGS: "-A warnings"
-          SUDO: ${{ inputs.sudo-key }}
-        run: |
-          # override cargo cmd to use forklift
-          echo 'CARGO_CMD="forklift cargo"' >> .env
-          # create dst dir
-          mkdir -p ${ZOMBIE_BITE_CI_PATH}
+  zombie_bite_polkadot:
+    uses: ./.github/workflows/zombie-bite-common.yml
+    with:
+      network: polkadot
+      sudo-key: ${{ inputs.sudo-key }}
 
-          # export sudo if is not empty
-           if [[ $SUDO != "" ]];then  export ZOMBIE_SUDO=$SUDO; else echo "no sudo key provided, using default '//Alice'";fi
-
-          just run-zombie-bite
-      - name: read_rc_block
-        id: read_rc_block
-        run: |
-            RC_BLOCK=$(cat $ZOMBIE_BITE_CI_PATH/rc-info.txt)
-            echo "RC_BLOCK=$RC_BLOCK" >> $GITHUB_OUTPUT
-      - name: upload_artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: zombie-bite-rc_block_${{steps.read_rc_block.outputs.RC_BLOCK}}-${{ github.sha }}
-          path: |
-            /tmp/ci/*
+  # TODO (Javier): westend doesn't works with doppelganger, I will implement fork-off (in genesis) as alternative
+  # zombie_bite_westend:
+  #   uses: ./.github/workflows/zombie-bite-common.yml
+  #   with:
+  #     network: westend
+  #     sudo-key: ${{ inputs.sudo-key }}

--- a/chopsticks-scripts/run_migration_westend.ts
+++ b/chopsticks-scripts/run_migration_westend.ts
@@ -1,0 +1,82 @@
+import { sendTransaction, setupNetworks, testingPairs } from "@acala-network/chopsticks-testing";
+import * as dotenv from 'dotenv';
+import type { KeyringPair } from '@polkadot/keyring/types'
+
+dotenv.config();
+const { polkadot, assetHub } = await setupNetworks({
+    polkadot: {
+        endpoint: `ws://localhost:${process.env.RELAY_NODE_RPC_PORT}`, 
+        // block: 25945950,
+        "wasm-override": "runtime_wasm/westend_runtime.compact.compressed.wasm",
+        "prefetch-storages": ["0x"], // universal prefix
+        db: "./dbs/westend.sqlite",
+        port: 8002,
+        timeout: 999999999999,
+        maxMemoryBlockCount: 99999999999,
+        runtimeLogLevel: 4,
+        'rpc-timeout': 999999999999,
+        'build-block-mode': "Instant"
+    },
+    assetHub: {
+        endpoint: `ws://localhost:${process.env.AH_NODE_RPC_PORT}`, 
+        // block: 11651240,
+        "wasm-override": "runtime_wasm/asset_hub_westend_runtime.compact.compressed.wasm",
+        "prefetch-storages": ["0x"],
+        db: "./dbs/westend-asset-hub.sqlite",
+        port: 8003,
+        timeout: 999999999999,
+        maxMemoryBlockCount: 99999999999,
+        runtimeLogLevel: 4,
+        'rpc-timeout': 999999999999,
+        'build-block-mode': "Instant"
+    },
+});
+
+export const defaultAccounts: {
+    alice: KeyringPair
+  } = testingPairs('sr25519')
+
+async function getRcMigrationState() {
+    return (await polkadot.api.query.rcMigrator.rcMigrationStage()).toHuman()
+}
+
+async function getAhMigrationState() {
+    return (await assetHub.api.query.ahMigrator.ahMigrationStage()).toHuman()
+}
+
+await polkadot.dev.setStorage({
+    System: {
+      Account: [
+        [
+          [defaultAccounts.alice.address],
+          { providers: 1, data: { free: 1000e10 }, }
+        ],
+      ],
+    },
+  });
+
+await polkadot.dev.setStorage({
+    Sudo: {
+        Key: defaultAccounts.alice.address,
+    },
+});
+
+console.log("ahMigrationStage: ", await getAhMigrationState());
+console.log("rcMigrationStage: ", await getRcMigrationState());
+
+const startMigrationTx = polkadot.api.tx.sudo.sudo((polkadot.api.tx.rcMigrator.startDataMigration()))
+const startMigrationEvents = await sendTransaction(startMigrationTx.signAsync(defaultAccounts.alice))
+
+while ((await getRcMigrationState()) != "MigrationDone") {
+    await polkadot.dev.newBlock()
+    await assetHub.dev.newBlock()
+
+    console.log("ahMigrationStage: ", await getAhMigrationState());
+    console.log("rcMigrationStage: ", await getRcMigrationState());
+}
+
+await polkadot.dev.newBlock()
+await assetHub.dev.newBlock()
+
+console.log("ahMigrationStage: ", await getAhMigrationState());
+console.log("rcMigrationStage: ", await getRcMigrationState());

--- a/justfile
+++ b/justfile
@@ -2,10 +2,10 @@ mod coverage
 
 set dotenv-load
 
-# Getting root directory of this project even when in submodule context
-PROJECT_ROOT_PATH := `git -C "$(git rev-parse --show-superproject-working-tree || pwd)" rev-parse --show-toplevel`
+PROJECT_ROOT_PATH := `DIR="${JUSTFILE:-justfile}"; DIR="$(realpath "$DIR")"; echo "$(dirname "$DIR")"`
 
 # In CI some image doesn't have scp and we can fallback to cp
+
 cp_cmd := `which scp || which cp`
 
 # Fork network and run tests for polkadot from the post-migration state
@@ -107,29 +107,24 @@ build-kusama:
 
 # Build the polkadot runtimes and copy back
 build-polkadot *EXTRA:
-    cd ${RUNTIMES_PATH} && ${CARGO_CMD} build --release --features=metadata-hash {{EXTRA}} -p asset-hub-polkadot-runtime -p polkadot-runtime -p collectives-polkadot-runtime
+    cd ${RUNTIMES_PATH} && ${CARGO_CMD} build --release --features=metadata-hash {{ EXTRA }} -p asset-hub-polkadot-runtime -p polkadot-runtime -p collectives-polkadot-runtime
     {{ cp_cmd }} ${RUNTIMES_BUILD_ARTIFACTS_PATH}/wbuild/**/**.compact.compressed.wasm ./runtime_wasm/
-
 
 clean-westend:
     # cleanup is required for proper porting, as the porting procedure is not idempotent
     echo "Cleaning up any modifications to ${SDK_PATH}"
     cd "${SDK_PATH}" && case "${PWD}" in \
-        {{PROJECT_ROOT_PATH}}/polkadot-sdk) git reset --hard && git clean -fdx ;; \
+        {{ PROJECT_ROOT_PATH }}/polkadot-sdk) git reset --hard && git clean -fdx ;; \
         *) echo "ERROR: SDK_PATH must be a 'polkadot-sdk' directory but got ["${PWD}"] instead" && exit 1 ;; \
     esac
 
 init-westend:
-    command -v zepter || { echo "install zepter to proceed"; exit 1; }
-    command -v lz4 || { echo "install lz4 to proceed"; exit 1; }
-    command -v curl || { echo "install curl to proceed"; exit 1; }
-
     echo "Initializing Westend for building"
-    flag="{{PROJECT_ROOT_PATH}}/${SDK_PATH}/.initialized"; \
+    flag="{{ PROJECT_ROOT_PATH }}/${SDK_PATH}/.initialized"; \
     if [ ! -f "${flag}" ]; then \
       just clean-westend && \
       cd "${RUNTIMES_PATH}/integration-tests/ahm" && \
-        just port westend "{{PROJECT_ROOT_PATH}}/${SDK_PATH}" "cumulus/test/ahm" && \
+        just port westend "{{ PROJECT_ROOT_PATH }}/${SDK_PATH}" "cumulus/test/ahm" && \
           touch "${flag}"; \
     else \
       echo "Westend already initialized."; \
@@ -152,12 +147,10 @@ install-zombie-bite:
 
 create-polkadot-pre-migration-snapshot: build-doppelganger install-zombie-bite
     just build-polkadot "--features zombie-bite-sudo"
-
-    # run zombie-bite
-    PATH=$(pwd)/${DOPPELGANGER_PATH}/target/release:$PATH zombie-bite polkadot:./runtime_wasm/polkadot_runtime.compact.compressed.wasm asset-hub
+    PATH=$(pwd)/${DOPPELGANGER_PATH}/target/release:$PATH zombie-bite polkadot:./runtime_wasm/polkadot_runtime.compact.compressed.wasm asset-hub:./runtime_wasm/asset_hub_polkadot_runtime.compact.compressed.wasm
 
 create-westend-pre-migration-snapshot: build-westend build-doppelganger install-zombie-bite
-    PATH=$(pwd)/${DOPPELGANGER_PATH}/target/release:$PATH zombie-bite westend:./runtime_wasm/westend_runtime.compact.compressed.wasm asset-hub fork-off
+    PATH=$(pwd)/${DOPPELGANGER_PATH}/target/release:$PATH zombie-bite westend:./runtime_wasm/westend_runtime.compact.compressed.wasm asset-hub
 
 # Run script to upgrade Asset Hub runtime
 run-ah-upgrade:
@@ -168,7 +161,7 @@ test-prepare:
     npm install
 
 e2e-test *TEST:
-    cd ${PET_PATH} && yarn && yarn test {{TEST}}
+    cd ${PET_PATH} && yarn && yarn test {{ TEST }}
 
 e2e-westend-post-migration: build-westend
     cd ${PET_PATH} && yarn && yarn test westend

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "tsc",
     "chopsticks-migration": "node dist/chopsticks-scripts/run_migration.js",
+    "chopsticks-migration-westend": "node dist/chopsticks-scripts/run_migration_westend.js",
     "authorize-upgrade": "node dist/zombie-bite-scripts/authorize_upgrade_ah.js",
     "prettier": "prettier --write .",
     "clean": "rm -rf dist",


### PR DESCRIPTION
Set of changes to eventually run PET tests against Westend runtimes

TODO:

include in the justfile whatever is needed to allow:
- [x] building Westend runtimes based on donal-ahm branch for relay and asset hub
- [ ] using zombie-bite to create pre-migration snapshots for westend relay and westend asset hub
- [ ] running local network based on the pre-migration snapshot
- [ ] running migration till completion on local network spawned by zombie-cli and save as post-migration snaphsot
- [ ] running local network based on the post-migration snapshot
- [ ] pre-migration test: allow to run PET tests using local network spawned from pre-migration snapshots while overriding wasms built from donal-ahm
- [ ] post-migration tests: allow to run PET tests using local network spawned from post-migration snapshots while overriding wasms built from donal-ahm



# READ NOTES BELOW

To run Westend migration with this PR:

in terminal 1 run:
`just run-westend-relay-local-node-docker`

in terminal 2 run:
`just run-westend-assethub-local-node-docker`

in terminal 3 run:
`just run-westend-migration`


Currently, building Westend Asset Hub WASM has issue with `runtime_version` section (@ggwpez is aware and will fix),
In the meantime after building the wasm it needs some `dd` magic:

go to `ahm-dryrun/polkadot-sdk/target/release/wbuild/asset-hub-westend-runtime` and get non compressed wasm `asset_hub_westend_runtime.wasm`

execute:
```
dd if=asset_hub_westend_runtime.wasm bs=1 count=$((0x0f33d25 + 0x34)) of=part1.bin
dd if=asset_hub_westend_runtime.wasm bs=1 skip=$((0x0f33d25 + 0x34 + (0x5d - 0x34))) of=part2.bin
cat part1.bin part2.bin > asset_hub_westend_runtime.wasm
printf '\\x34' | dd of=asset_hub_westend_runtime.wasm bs=1 seek=$((0x0f33d25 - 1)) count=1 conv=notrunc
```

where `0x0f33d25` is the start address of the section: `wasm-objdump -s -j "runtime_version"`

use modified `asset_hub_westend_runtime.wasm` in `run_migration_westend.ts` script `wasm-override` part