### PR TITLE
Fixing CI: fatal: detected dubious ownership in repository

### DIFF
--- a/.github/workflows/zombie-bite-common.yml
+++ b/.github/workflows/zombie-bite-common.yml
@@ -34,7 +34,6 @@ jobs:
           RUSTFLAGS: "-A warnings"
           SUDO: ${{ inputs.sudo-key }}
         run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           echo 'CARGO_CMD="forklift cargo"' >> .env
           mkdir -p ${ZOMBIE_BITE_CI_PATH}
 
@@ -45,7 +44,7 @@ jobs:
           fi
 
           apt-get update && apt-get install -y lz4 rsync
-          just submodule-update
+
           just create-${{ inputs.network }}-pre-migration-snapshot
           
       - name: read_rc_block

--- a/.github/workflows/zombie-bite-common.yml
+++ b/.github/workflows/zombie-bite-common.yml
@@ -34,6 +34,7 @@ jobs:
           RUSTFLAGS: "-A warnings"
           SUDO: ${{ inputs.sudo-key }}
         run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           echo 'CARGO_CMD="forklift cargo"' >> .env
           mkdir -p ${ZOMBIE_BITE_CI_PATH}
 


### PR DESCRIPTION
Trying to fix CI error like:

```
fatal: detected dubious ownership in repository at '/__w/ahm-dryrun/ahm-dryrun'
To add an exception for this directory, call:

	git config --global --add safe.directory /__w/ahm-dryrun/ahm-dryrun
error: Recipe `submodule-update` failed on line 44 with exit code 128
```

as did happen in https://github.com/paritytech/ahm-dryrun/actions/runs/14888764269/job/41815309955#step:6:87