### PR TITLE
override ah runtime as part of zombie-bite

### DIFF
--- a/.github/workflows/zombie-bite-common.yml
+++ b/.github/workflows/zombie-bite-common.yml
@@ -25,9 +25,6 @@ jobs:
         with:
           submodules: recursive
       - uses: extractions/setup-just@v2
-      - name: install_zombie-bite
-        run: |
-          cargo install --git https://github.com/pepoviola/zombie-bite --bin zombie-bite
       - name: zombie_bite
         shell: bash
         env:
@@ -46,7 +43,7 @@ jobs:
           apt-get update && apt-get install -y lz4 rsync
 
           just create-${{ inputs.network }}-pre-migration-snapshot
-          
+
       - name: read_rc_block
         id: read_rc_block
         run: |

--- a/.github/workflows/zombie-bite.yml
+++ b/.github/workflows/zombie-bite.yml
@@ -23,6 +23,7 @@ jobs:
       network: polkadot
       sudo-key: ${{ inputs.sudo-key }}
 
+  # TODO (Javier): westend doesn't works with doppelganger, I will implement fork-off (in genesis) as alternative
   # zombie_bite_westend:
   #   uses: ./.github/workflows/zombie-bite-common.yml
   #   with:

--- a/.github/workflows/zombie-bite.yml
+++ b/.github/workflows/zombie-bite.yml
@@ -23,8 +23,8 @@ jobs:
       network: polkadot
       sudo-key: ${{ inputs.sudo-key }}
 
-  zombie_bite_westend:
-    uses: ./.github/workflows/zombie-bite-common.yml
-    with:
-      network: westend
-      sudo-key: ${{ inputs.sudo-key }}
+  # zombie_bite_westend:
+  #   uses: ./.github/workflows/zombie-bite-common.yml
+  #   with:
+  #     network: westend
+  #     sudo-key: ${{ inputs.sudo-key }}

--- a/justfile
+++ b/justfile
@@ -95,7 +95,7 @@ install-zombie-bite:
 
 create-polkadot-pre-migration-snapshot: build-doppelganger install-zombie-bite
     just build-polkadot "--features zombie-bite-sudo"
-    PATH=$(pwd)/${DOPPELGANGER_PATH}/target/release:$PATH zombie-bite polkadot:./runtime_wasm/polkadot_runtime.compact.compressed.wasm asset-hub
+    PATH=$(pwd)/${DOPPELGANGER_PATH}/target/release:$PATH zombie-bite polkadot:./runtime_wasm/polkadot_runtime.compact.compressed.wasm asset-hub:./runtime_wasm/asset_hub_polkadot_runtime.compact.compressed.wasm
 
 create-westend-pre-migration-snapshot: build-westend build-doppelganger install-zombie-bite
     PATH=$(pwd)/${DOPPELGANGER_PATH}/target/release:$PATH zombie-bite westend:./runtime_wasm/westend_runtime.compact.compressed.wasm asset-hub


### PR DESCRIPTION
- Add override for AH
- comment _westend_, since doesn't work wit warp sync
- remove extra install for zombie-bite, since is installed using `just` 

Thx!