### PR TITLE
pallet voter_list

### DIFF
--- a/migration-tests/index.ts
+++ b/migration-tests/index.ts
@@ -4,9 +4,10 @@ import '@polkadot/types-augment';
 import { ApiPromise, WsProvider } from '@polkadot/api';
 import { TestContext, PalletTest } from './types.js';
 import { vestingTests } from './pallets/vesting.js';
+import { voterListTests } from './pallets/staking/bags_list.js';
 
 // Array of all pallet tests
-const palletTests: PalletTest[] = [vestingTests];
+const palletTests: PalletTest[] = [vestingTests, voterListTests];
 
 async function runTests(context: TestContext) {
     console.log('Starting migration verification tests...\n');

--- a/migration-tests/pallets/staking/bags_list.ts
+++ b/migration-tests/pallets/staking/bags_list.ts
@@ -1,0 +1,62 @@
+import '@polkadot/api-augment';
+import { PalletTest } from '../../types.js';
+import assert from 'assert';
+
+export const voterListTests: PalletTest = {
+    pallet_name: 'voter_list',
+    pre_check: async ({ ah_api_before }) => {
+        const listNodes = await ah_api_before.query.voterList.listNodes.entries();
+        assert(listNodes.length === 0, 'Assert storage voterList.listNodes() is empty before migration');
+
+        const listBags = await ah_api_before.query.voterList.listBags.entries();
+        assert(listBags.length === 0, 'Assert storage voterList.listBags() is empty before migration');
+    },
+    post_check: async ({ rc_api_before, ah_api_after, rc_api_after }) => {
+        const rc_nodes_after = await rc_api_after.query.voterList.listNodes.entries();
+        const rc_bags_after = await rc_api_after.query.voterList.listBags.entries();
+        assert(rc_nodes_after.length === 0, 'Assert RC storage voterList.listNodes() is empty after migration');
+        assert(rc_bags_after.length === 0, 'Assert RC storage voterList.listBags() is empty after migration');
+
+        const nodes_before = await rc_api_before.query.voterList.listNodes.entries();
+        const nodes_after = await ah_api_after.query.voterList.listNodes.entries();
+        assert(nodes_before.length > 0, 'Assert storage voterList.listNodes() is not empty before migration');
+        assert(nodes_before.length === nodes_after.length, 'Assert storage voterList.listNodes() length matches before and after migration');
+
+        // Convert node entries to maps for comparison
+        const nodes_before_map = new Map(nodes_before.map(([key, value]) => [key.toString(), value.toJSON()]));
+        const nodes_after_map = new Map(nodes_after.map(([key, value]) => [key.toString(), value.toJSON()]));
+
+        // Check that all node entries match
+        for (const [key, beforeValue] of nodes_before_map) {
+            const afterValue = nodes_after_map.get(key);
+            assert(afterValue !== undefined, `Missing node key ${key} in post-migration nodes`);
+            assert.deepStrictEqual(beforeValue, afterValue, `Node value mismatch for key ${key}`);
+        }
+
+        // Check no extra node entries exist
+        for (const [key] of nodes_after_map) {
+            assert(nodes_before_map.has(key), `Unexpected node key ${key} in post-migration nodes`);
+        }
+
+        const bags_before = await rc_api_before.query.voterList.listBags.entries();
+        const bags_after = await ah_api_after.query.voterList.listBags.entries();
+        assert(bags_before.length > 0, 'Assert storage voterList.listBags() is not empty before migration');
+        assert(bags_before.length === bags_after.length, 'Assert storage voterList.listBags() length matches before and after migration');
+
+        // Convert bag entries to maps for comparison
+        const bags_before_map = new Map(bags_before.map(([key, value]) => [key.toString(), value.toJSON()]));
+        const bags_after_map = new Map(bags_after.map(([key, value]) => [key.toString(), value.toJSON()]));
+
+        // Check that all bag entries match
+        for (const [key, beforeValue] of bags_before_map) {
+            const afterValue = bags_after_map.get(key);
+            assert(afterValue !== undefined, `Missing bag key ${key} in post-migration bags`);
+            assert.deepStrictEqual(beforeValue, afterValue, `Bag value mismatch for key ${key}`);
+        }
+
+        // Check no extra bag entries exist
+        for (const [key] of bags_after_map) {
+            assert(bags_before_map.has(key), `Unexpected bag key ${key} in post-migration bags`);
+        }
+    }
+}; 


### PR DESCRIPTION
It maps [bags list](https://github.com/polkadot-fellows/runtimes/blob/6048e1c18f36a9e00ea396d39b456f5e92ba1552/pallets/rc-migrator/src/staking/bags_list.rs) from Rust framework. It's a nomination pool data migration module