### PR TITLE
Update ahm tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,20 +26,27 @@ just build-runtimes
 just run
 ```
 
-### E2E Tests on Asset Hub Next
+### E2E Tests on Westend Asset Hub
 
-To run PET'S currently existing E2E test suites on the AHNW, use
+Polkadot Ecosystem Tests offers, among other things, a suite of E2E tests that run against
+live networks.
+The PET submodule in this repository is set to branch `ahm-tests`, which adapts the (originally) relaychain E2E suites
+to run in post-migration Westend Asset Hub.
+
+To run these E2E tests:
 
 ```sh
-#runs all of them, AHNW and beyond
+# runs every PET test
+# this will run the adapted test suites on Polkadot/Kusama, and **cause failures** as test suites for AH are
+# incompatible with relaychain
 just e2e-tests
 
-# runs all suites from current E2E suites that have been adapted to the AHNW
-just e2e-tests assetHubNext
+# runs all E2E suites that have been adapted to WAH
+just wah-e2e-tests
 
-# specific test suite(s)
-just e2e-tests assetHubNext.scheduler
-just e2e-tests assetHubNext.staking assetHubNext.nominationPools
+# run specific test suite(s)
+just e2e-tests scheduler
+just e2e-tests staking nominationPools
 ...
 ```
 

--- a/justfile
+++ b/justfile
@@ -113,8 +113,17 @@ run-ah-upgrade:
 test-prepare:
     npm install
 
-e2e-test *TEST:
+e2e-tests *TEST:
     cd ${PET_PATH} && yarn && yarn test {{ TEST }}
+
+wah-e2e-tests *TEST:
+    #!/usr/bin/env bash
+    # if no test modules are provided, run all of them
+    tests="assetHubWestend."
+    for test in {{ TEST }}; do
+        tests="$tests assetHubWestend.$test"
+    done
+    just e2e-tests $tests
 
 # Run the tests
 test:


### PR DESCRIPTION
https://github.com/open-web3-stack/polkadot-ecosystem-tests/pull/270 did most of the work required to enable running existing PET E2E test suites on post-migration WAH.

This PR bumps the PET submodule to include those changes.