### PR TITLE
Post migration tests accept command line arguments

### DIFF
--- a/ahm-dryrun-mock/orchestrator.ts
+++ b/ahm-dryrun-mock/orchestrator.ts
@@ -30,6 +30,17 @@ class Orchestrator {
             }
 
             console.log('🧑‍🔧Starting migration process...');
+
+            // Start westend migration tests
+            console.log('🧑‍🔧Starting westend migration tests in parallel...');
+            const westendTests = spawn('just', ['run-westend-migration-tests'], {
+                stdio: 'inherit'
+            });
+
+            westendTests.on('error', (err) => {
+                console.error('🧑‍🔧Failed to start westend migration tests:', err);
+                process.exit(1);
+            });
             
 
             // Start zombie-bite process


### PR DESCRIPTION
In order to function properly and to be able to use `just` commands, we need to move orchestrator to the folder above. 
As well as get rid of two `package.json` and two `justfile`s to reduce confusion.

I envisioned that PoC PR as just a PoC but I am happy that it was good enough so you started developing on that branch!