### PR TITLE
Added an option to exclude selected migration tests by network

### DIFF
--- a/migration-tests/lib.ts
+++ b/migration-tests/lib.ts
@@ -11,7 +11,7 @@ import { convictionVotingTests } from "./pallets/conviction_voting.js";
 import { indicesTests } from "./pallets/indices.js";
 
 // when updating this, also update the testsByNetwork below
-type Network = "Westend" | "Paseo" | "Polkadot";
+type Network = "Westend" | "Paseo" | "Kusama" | "Polkadot";
 
 // All available tests
 const allTests = [
@@ -27,6 +27,7 @@ const allTests = [
 const excludedTestsByNetwork: Record<Network, MigrationTest[]> = {
   Westend: [],
   Paseo: [],
+  Kusama: [],
   Polkadot: [],
 };
 

--- a/migration-tests/lib.ts
+++ b/migration-tests/lib.ts
@@ -8,6 +8,7 @@ import { assetRateTests } from './pallets/asset_rate.js';
 import { proxyTests } from "./pallets/proxies.js";
 import { voterListTests } from './pallets/staking/voter_list.js';
 import { convictionVotingTests } from "./pallets/conviction_voting.js";
+import { indicesTests } from "./pallets/indices.js";
 // import { bountiesTests } from './pallets/bounties.js';
 
 // when updating this, also update the testsByNetwork below
@@ -15,11 +16,12 @@ type Network = "Westend" | "Paseo" | "Polkadot";
 
 // All available tests
 const allTests = [
-  vestingTests,
   assetRateTests,
   convictionVotingTests,
+  indicesTests,
   proxyTests,
-  voterListTests
+  voterListTests,
+  vestingTests
 ];
 
 // Excludes tests from all available tests

--- a/migration-tests/lib.ts
+++ b/migration-tests/lib.ts
@@ -9,7 +9,6 @@ import { proxyTests } from "./pallets/proxies.js";
 import { voterListTests } from './pallets/staking/voter_list.js';
 import { convictionVotingTests } from "./pallets/conviction_voting.js";
 import { indicesTests } from "./pallets/indices.js";
-// import { bountiesTests } from './pallets/bounties.js';
 
 // when updating this, also update the testsByNetwork below
 type Network = "Westend" | "Paseo" | "Polkadot";
@@ -108,20 +107,6 @@ export async function main(
 
   // Disconnect all APIs
   await Promise.all(apis.map((api) => api.disconnect()));
-
-  // Later you can use it as a key-value mapping
-  const testsByNetwork: Record<Network, MigrationTest[]> = {
-    Westend: [vestingTests, assetRateTests],
-    Paseo: [vestingTests],
-    Polkadot: [vestingTests, assetRateTests]
-  };
-
-  // Or as a Map
-  const testsMap = new Map<Network, MigrationTest[]>([
-    ["Westend", [vestingTests, assetRateTests]],
-    ["Paseo", [vestingTests]],
-    ["Polkadot", [vestingTests, assetRateTests]]
-  ]);
 }
 
 export interface ChainConfig {


### PR DESCRIPTION
It will unblock adding [pallet bounties tests](https://github.com/paritytech/ahm-dryrun/pull/59) which need to be excluded from Westend test suite.