### PR TITLE
Understanding orchestrator issue

### DIFF
--- a/justfile
+++ b/justfile
@@ -149,3 +149,7 @@ clean:
 run-westend-migration-tests:
     npm run build
     npm run compare-state
+
+test-schedule-migration:
+    npm run build
+    npm run scheduler-test

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "report-account-migration-status": "node dist/zombie-bite-scripts/report_account_migration_status.js",
     "compare-state": "node dist/migration-tests/index.js",
     "polkadot-migration": "RUST_LOG=zombie=debug node dist/zombie-bite-scripts/orchestrator.js",
+    "scheduler-test": "node dist/zombie-bite-scripts/scheduler_test.js",
     "prettier": "prettier --write .",
     "clean": "rm -rf dist",
     "postinstall": "papi"

--- a/zombie-bite-scripts/orchestrator.ts
+++ b/zombie-bite-scripts/orchestrator.ts
@@ -58,13 +58,13 @@ class Orchestrator {
       console.log("\t\t 📩 Ready info received:", start_blocks, ports);
       const { alice_port, collator_port } = ports;
 
-      console.log(`\t 🧑‍🔧 Triggering migration with alice_port: ${alice_port}`);
-      await scheduleMigration(alice_port);
+      // console.log(`\t 🧑‍🔧 Triggering migration with alice_port: ${alice_port}`);
+      // await scheduleMigration(alice_port);
 
-      console.log(
-        `\t 🧑‍🔧 Starting monitoring until miragtion finish with ports: ${alice_port}, ${collator_port}`,
-      );
-      this.monitMigrationFinishWrapper(base_path, alice_port, collator_port);
+      // console.log(
+      //   `\t 🧑‍🔧 Starting monitoring until miragtion finish with ports: ${alice_port}, ${collator_port}`,
+      // );
+      // this.monitMigrationFinishWrapper(base_path, alice_port, collator_port);
 
       console.log("\t 🧑‍🔧 Waiting for migration info...");
       let end_blocks = await this.waitForMigrationInfo(base_path);

--- a/zombie-bite-scripts/scheduler_test.ts
+++ b/zombie-bite-scripts/scheduler_test.ts
@@ -1,0 +1,60 @@
+import { cryptoWaitReady } from "@polkadot/util-crypto";
+import { ApiPromise, WsProvider, Keyring } from "@polkadot/api";
+
+const finalization = false;
+
+export async function scheduleMigration(rc_port?: number) {
+    const rc_uri = `ws://localhost:${rc_port || 63168}`;
+    await cryptoWaitReady();
+    console.log("cryptoWaitReady");
+  
+    const keyring = new Keyring({ type: "sr25519" });
+    const alice = keyring.addFromUri("//Alice");
+    console.log("keyring alice");
+  
+    const api = await connect(rc_uri);
+    console.log("api");
+    // @ts-ignore
+    let nonce = (await api.query.system.account(alice.address)).nonce.toNumber();
+    console.log("nonce");
+    const unsub: any = await api.tx.sudo
+      .sudo(api.tx.rcMigrator.scheduleMigration({ after: 1 }))
+      .signAndSend(alice, { nonce: nonce, era: 0 }, (result) => {
+        console.log(`Current status is ${result.status}`);
+        if (result.status.isInBlock) {
+          console.log(
+            `Transaction included at blockhash ${result.status.asInBlock}`,
+          );
+          if (finalization) {
+            console.log("Waiting for finalization...");
+          } else {
+            finish(unsub, api);
+          }
+        } else if (result.status.isFinalized) {
+          console.log(
+            `Transaction finalized at blockHash ${result.status.asFinalized}`,
+          );
+          return finish(unsub, api);
+        } else if (result.isError) {
+          console.log(`Transaction error`);
+          return finish(unsub, api);
+        }
+      });
+  }
+
+  async function connect(apiUrl: string, types = {}) {
+    const provider = new WsProvider(apiUrl);
+    const api = new ApiPromise({ provider, types });
+    await api.isReady;
+    return api;
+  }
+  async function finish(unsub: any, api: any) {
+    unsub();
+    api.disconnect();
+  }
+
+  async function main() {
+    await scheduleMigration(63168);
+  }
+
+  main().catch(console.log);


### PR DESCRIPTION
Added a set-up to test scheduler independently of the orchestrator itself.
The flow is the following:
- terminal 1: as usual run `just run-orchestrator-polkadot`
- once the network is spawned run `just test-schedule-migration` in another terminal