### PR TITLE
Excluded convictionVotingTests from Westend network

### DIFF
--- a/migration-tests/lib.ts
+++ b/migration-tests/lib.ts
@@ -105,7 +105,6 @@ export async function main(
   );
 
   await treasury_spend();
-  return;
   // to correctly state assert, the best is to take Westend before 1st and WAH after 2nd,
   // though knowing that between 1st and 2nd migration in WAH, few users might have added few things
   // so a small mismatch might be expected.

--- a/migration-tests/lib.ts
+++ b/migration-tests/lib.ts
@@ -26,9 +26,9 @@ const allTests = [
   bountiesTests
 ];
 
-// Excludes tests from all available tests
-const excludedTestsByNetwork: Record<Network, MigrationTest[]> = {
-  Westend: [bountiesTests],
+// Excludes tests from the pool of all available tests
+const excludedTestsPerNetwork: Record<Network, MigrationTest[]> = {
+  Westend: [bountiesTests, convictionVotingTests],
   Paseo: [],
   Kusama: [],
   Polkadot: [],
@@ -36,7 +36,7 @@ const excludedTestsByNetwork: Record<Network, MigrationTest[]> = {
 
 // Function to get tests for a specific network
 function getTestsForNetwork(network: Network): MigrationTest[] {
-  const excludedTests = excludedTestsByNetwork[network];
+  const excludedTests = excludedTestsPerNetwork[network];
   return allTests.filter(test => !excludedTests.includes(test));
 }
 
@@ -105,6 +105,7 @@ export async function main(
   );
 
   await treasury_spend();
+  return;
   // to correctly state assert, the best is to take Westend before 1st and WAH after 2nd,
   // though knowing that between 1st and 2nd migration in WAH, few users might have added few things
   // so a small mismatch might be expected.

--- a/migration-tests/lib.ts
+++ b/migration-tests/lib.ts
@@ -28,7 +28,12 @@ const allTests = [
 
 // Excludes tests from the pool of all available tests
 const excludedTestsPerNetwork: Record<Network, MigrationTest[]> = {
-  Westend: [bountiesTests, convictionVotingTests],
+  Westend: [
+    // the pallet is not available on Westend
+    bountiesTests,
+    // https://github.com/paritytech/ahm-dryrun/issues/67
+    convictionVotingTests
+  ],
   Paseo: [],
   Kusama: [],
   Polkadot: [],


### PR DESCRIPTION
Logging 400+ entries does not make sense thus fully disabled that test.
Also improved map name and description.