### PR TITLE
Changed origin of treasury spend call

### DIFF
--- a/migration-tests/chopsticks.ts
+++ b/migration-tests/chopsticks.ts
@@ -51,7 +51,7 @@ export async function treasury_spend(): Promise<void> {
                             Inline: treasurySpendCall,
                         },
                         origin: {
-                            System: 'Root'
+                            Origins: 'BigSpender'
                         }
                     }],
                 ],


### PR DESCRIPTION
as per https://github.com/paritytech/ahm-dryrun/pull/80#discussion_r2194472847