### PR TITLE
fix: programmatically build treasury.spend call

### DIFF
--- a/migration-tests/chopsticks.ts
+++ b/migration-tests/chopsticks.ts
@@ -75,6 +75,7 @@ export async function treasury_spend(): Promise<void> {
 			}
 		}
 	} as unknown as XcmVersionedLocation;
+    // validFrom - null, which means immediately.	
     const call = polkadot.api.tx.treasury.spend(assetKind, amount, beneficiary, null);
     const hexCall = call.method.toHex();
     

--- a/migration-tests/chopsticks.ts
+++ b/migration-tests/chopsticks.ts
@@ -16,6 +16,8 @@ export async function treasury_spend(): Promise<void> {
     const aliceSS58 = '15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5';
     const aliceHEX = '0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d';
     const USDT_ID = 1984;
+    const ASSET_HUB_PARA_ID = 1000;
+    const ASSETS_PALLET_ID = 50;
 
     const {polkadot, assetHub} = await setupNetworks({
         polkadot: {
@@ -38,7 +40,7 @@ export async function treasury_spend(): Promise<void> {
                 "interior": {
                     "x1": [
                         {
-                            "parachain": 1000
+                            "parachain": ASSET_HUB_PARA_ID
                         }
                     ]
                 }
@@ -48,10 +50,10 @@ export async function treasury_spend(): Promise<void> {
                 "interior": {
                     "x2": [
                         {
-                            "palletInstance": 50
+                            "palletInstance": ASSETS_PALLET_ID
                         },
                         {
-                            "generalIndex": 1984
+                            "generalIndex": USDT_ID
                         }
                     ]
                 }
@@ -66,7 +68,7 @@ export async function treasury_spend(): Promise<void> {
 					{
 						"accountId32": {
 							"network": null,
-							"id": "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"
+							"id": aliceHEX
 						}
 					}
 				]


### PR DESCRIPTION
closes: https://github.com/paritytech/ahm-dryrun/issues/106

This PR focuses on programmatically building the treasury spend call. Main concerns, it builds the `assetKind` type from scratch as well as the `beneficiary` type from scratch, and it cleans up some variable usage.