### PR TITLE
[DNM] update zombie-bite readme

### DIFF
--- a/zombie-bite/README.md
+++ b/zombie-bite/README.md
@@ -77,7 +77,7 @@ node_spawn_timeout = 600
 
 [relaychain]
 chain = "polkadot"
-default_command = "doppelganger"
+default_command = "polkadot"
 default_db_snapshot = "./polkadot-snap.tgz"
 default_args = [
     "-l=babe=trace,grandpa=info,runtime=trace,consensus::common=trace,parachain=debug",

--- a/zombie-bite/README.md
+++ b/zombie-bite/README.md
@@ -45,3 +45,84 @@ For both you need to set the _env var_ `ZOMBIE_BITE_RC_PORT` from the rpc port o
 
 
 You should get a new network with the `live state` running locally.
+
+
+---
+
+### Other alternatives:
+
+#### How to use a custom `wasm` (polkadot/ah)
+
+In the case you want to provide a custom wasm (and not build it as part of the flow), you can use this steps to get a new network spawned:
+
+- `just build-doppelganger`
+- `just install-zombie-bite`
+- `source .env`
+- `PATH=$(pwd)/${DOPPELGANGER_PATH}/target/release:$PATH zombie-bite polkadot:<path to compact.compressed.wasm> asset-hub:<path to compact.compressed.wasm>`
+
+
+This will spawn the network, with the runtimes overridden.
+
+
+#### How to use zombie-cli to spawn a network with a custom `wasm` and `snapshot`
+
+In the case you have a _custom snapshot_ and _wasm_ and you want to spawn a network, you can use `zombie-cli` to use it. For that you need to create a _toml_ configuration of your network.
+
+For example (config.toml):
+
+```toml
+[settings]
+timeout = 3600
+node_spawn_timeout = 600
+
+[relaychain]
+chain = "polkadot"
+default_command = "doppelganger"
+default_db_snapshot = "./polkadot-snap.tgz"
+default_args = [
+    "-l=babe=trace,grandpa=info,runtime=trace,consensus::common=trace,parachain=debug",
+    "--discover-local",
+    "--allow-private-ip",
+    "--no-hardware-benchmarks",
+]
+chain_spec_path = "./polkadot-spec.json"
+
+[[relaychain.nodes]]
+name = "alice"
+rpc_port = 63168
+
+[[relaychain.nodes]]
+name = "bob"
+
+
+[[parachains]]
+id = 1000
+chain = "asset-hub-polkadot"
+default_command = "polkadot-parachain"
+default_db_snapshot = "./asset-hub-polkadot-snap.tgz"
+chain_spec_path = "./asset-hub-polkadot-spec.json"
+
+[[parachains.collators]]
+name = "collator"
+args = [
+    "--relay-chain-rpc-urls=ws://127.0.0.1:63168",
+    "-l=aura=debug,runtime=debug,cumulus-consensus=trace,consensus::common=trace,parachain::collation-generation=trace,parachain::collator-protocol=trace,parachain=debug",
+    "--force-authoring",
+    "--discover-local",
+    "--allow-private-ip",
+    "--no-hardware-benchmarks",
+]
+rpc_port = 63170
+
+```
+
+_NOTE_:In this case, since we are providing also a custom `chain-spec` for both (rc/ah).
+
+And then you can run:
+
+```
+RUST_LOG=zombie=debug zombie-cli spawn -p native config.toml
+```
+
+
+


### PR DESCRIPTION
Add alternatives to spawn a network with: 

- Custom `wasm` (not build as part of the process)
- Custom `wasm` and `snapshot` (directly with zombie-cli)

