### PR TITLE
Partially implemented referenda converter

### DIFF
--- a/migration-tests/pallets/referenda.ts
+++ b/migration-tests/pallets/referenda.ts
@@ -2,8 +2,9 @@ import '@polkadot/api-augment';
 import assert from 'assert';
 import { PreCheckContext, PostCheckContext, MigrationTest, PreCheckResult } from '../types.js';
 import type { Codec } from '@polkadot/types/types';
-import type { StorageKey } from '@polkadot/types';
+import type { StorageKey, u32 } from '@polkadot/types';
 import { ApiDecoration } from '@polkadot/api/types';
+import { ReferendumInfo } from '@polkadot/types/interfaces/democracy/types.js';
 
 export const referendaTests: MigrationTest = {
     name: 'referenda_pallet',
@@ -120,11 +121,11 @@ async function verifyRcStorageEmpty(rc_api_after: ApiDecoration<'promise'>): Pro
 
 async function verifyAhStorageMatchesRcPreMigrationData(
     ah_api_after: ApiDecoration<'promise'>,
-    rc_referendumCount: Codec,
-    rc_decidingCount: [StorageKey, Codec][],
+    rc_referendumCount: u32,
+    rc_decidingCount: [StorageKey, u32][],
     rc_trackQueue: [StorageKey, Codec][],
     rc_metadata: [StorageKey, Codec][],
-    rc_referendumInfo: [StorageKey, Codec][]
+    rc_referendumInfo: [StorageKey, ReferendumInfo][]
 ): Promise<void> {
     // Check referendum count matches RC pre-migration value
     const ah_referendumCount = await ah_api_after.query.referenda.referendumCount();
@@ -148,7 +149,7 @@ async function verifyAhStorageMatchesRcPreMigrationData(
 
     // Check referendum info
     const ah_after_referendumInfo = await ah_api_after.query.referenda.referendumInfoFor.entries();
-    verifyReferendumInfo(rc_referendumInfo, ah_after_referendumInfo as unknown as [StorageKey, Codec][]);
+    await verifyReferendumInfo(ah_api_after, rc_referendumInfo, ah_after_referendumInfo as unknown as [StorageKey, Codec][]);
 }
 
 function verifyDecidingCount(rc_before_decidingCount: [StorageKey, Codec][], ah_after_decidingCount: [StorageKey, Codec][]): void {
@@ -222,13 +223,13 @@ function verifyMetadata(rc_before_metadata: [StorageKey, Codec][], ah_after_meta
 
 // reference implementation from Rust code: 
 // https://github.com/polkadot-fellows/runtimes/blob/6048e1c18f36a9e00ea396d39b456f5e92ba1552/pallets/ah-migrator/src/referenda.rs#L371C3-L491C4
-function verifyReferendumInfo(rc_before_referendumInfo: [StorageKey, Codec][], ah_after_referendumInfo: [StorageKey, Codec][]): void {
+async function verifyReferendumInfo(ah_api_after: ApiDecoration<'promise'>, rc_before_referendumInfo: [StorageKey, Codec][], ah_after_referendumInfo: [StorageKey, Codec][]): Promise<void> {
     // Convert RC referenda to expected AH format
-    const expectedAhReferenda = rc_before_referendumInfo.map(([key, rcInfo]) => {
+    const expectedAhReferenda = await Promise.all(rc_before_referendumInfo.map(async ([key, rcInfo]) => {
         const refIndex = key.args[0].toString();
-        const convertedInfo = convertRcToAhReferendum(rcInfo);
+        const convertedInfo = await convert_rc_to_ah_referendum(ah_api_after, rcInfo);
         return [refIndex, convertedInfo] as [string, Codec];
-    });
+    }));
 
     // Get current AH referenda
     const currentAhReferenda = ah_after_referendumInfo.map(([key, info]) => {
@@ -256,28 +257,100 @@ function verifyReferendumInfo(rc_before_referendumInfo: [StorageKey, Codec][], a
     }
 }
 
-function convertRcToAhReferendum(rcInfo: Codec): Codec {
+async function convert_rc_to_ah_referendum(ah_api_after: ApiDecoration<'promise'>, rcInfo: Codec): Promise<Codec> {
     const rcInfoJson = rcInfo.toJSON() as any;
     
     // Handle different referendum states
     if (rcInfoJson.Ongoing) {
         const rcStatus = rcInfoJson.Ongoing;
-        // TODO: implement the actual conversion logic
-        // https://github.com/polkadot-fellows/runtimes/blob/6048e1c18f36a9e00ea396d39b456f5e92ba1552/pallets/ah-migrator/src/referenda.rs#L377-L422
-        return rcInfo;
+
+        // Try to convert RC proposal/call
+        const ah_proposal = await map_rc_ah_call(ah_api_after, rcStatus);
+        if (!ah_proposal) {
+            // Call conversion failed, return cancelled
+            const now = get_current_block_number();
+            return create_cancelled_referendum(now, rcStatus.submission_deposit, rcStatus.decision_deposit);
+        }
+
+        // Construct the AH status using converted parts
+        const ah_status = {
+            track: rcStatus.track,
+            // unlike Rust, there is no need to convert origin here; json are mapped 1:1
+            origin: rcStatus.origin,
+            proposal: ah_proposal,
+            enactment: rcStatus.enactment,
+            submitted: rcStatus.submitted,
+            submission_deposit: rcStatus.submission_deposit,
+            decision_deposit: rcStatus.decision_deposit,
+            deciding: rcStatus.deciding,
+            tally: rcStatus.tally,
+            in_queue: rcStatus.in_queue,
+            alarm: rcStatus.alarm,
+        };
+
+        return create_ongoing_referendum(ah_status);
     } else if (rcInfoJson.Approved) {
-        return rcInfo;
+        return rcInfo; // No conversion needed
     } else if (rcInfoJson.Rejected) {
-        return rcInfo;
+        return rcInfo; // No conversion needed
     } else if (rcInfoJson.Cancelled) {
-        return rcInfo;
+        return rcInfo; // No conversion needed
     } else if (rcInfoJson.TimedOut) {
-        return rcInfo;
+        return rcInfo; // No conversion needed
     } else if (rcInfoJson.Killed) {
-        return rcInfo;
+        return rcInfo; // No conversion needed
     }
-    
+
     return rcInfo;
+}
+
+// Helper function to convert RC call to AH call
+async function map_rc_ah_call(ah_api_after: ApiDecoration<'promise'>, rcStatus: any): Promise<any | null> {
+    const encodedCall = await fetch_preimage(ah_api_after, rcStatus);
+    if (!encodedCall) {
+        return null;
+    }
+
+    return convert_rc_to_ah_call(ah_api_after, encodedCall)
+}
+
+async function convert_rc_to_ah_call(ah_api_after: ApiDecoration<'promise'>, encodedCall: any): Promise<any | null> {
+    // TODO: implement decode(encodedCall) + map(decodedCall)
+    //  https://github.com/polkadot-fellows/runtimes/blob/6048e1c18f36a9e00ea396d39b456f5e92ba1552/system-parachains/asset-hubs/asset-hub-polkadot/src/ah_migration/mod.rs#L238-L360
+    return encodedCall;
+}
+
+async function fetch_preimage(ah_api_after: ApiDecoration<'promise'>, rcStatus: any): Promise<any> {
+    if (rcStatus.proposal.inline) {
+        return rcStatus.proposal.inline;
+    } else if (rcStatus.proposal.lookup) {
+        return await ah_api_after.query.preimage.requestPreimage(rcStatus.proposal.lookup.hash);
+    } else if (rcStatus.proposal.legacy) {
+        return await ah_api_after.query.preimage.fetch(rcStatus.proposal.legacy.hash);
+    } else {
+        return null;
+    }
+}
+
+// Helper function to create a cancelled referendum
+function create_cancelled_referendum(now: number, submission_deposit: any, decision_deposit: any): any {
+    return {
+        Cancelled: [now, submission_deposit, decision_deposit]
+    };
+}
+
+// Helper function to create an ongoing referendum
+function create_ongoing_referendum(status: any): any {
+    return {
+        Ongoing: status
+    };
+}
+
+// Helper function to get current block number
+function get_current_block_number(): number {
+    // TODO: this requires implementation later on too
+    // For now, return a placeholder value
+    return 1;
 }
 
 function referendumsEqual(ref1: Codec, ref2: Codec): boolean {


### PR DESCRIPTION
Converting Relay call to AH call still requires implementation. 
[The conversion logic](https://github.com/polkadot-fellows/runtimes/blob/6048e1c18f36a9e00ea396d39b456f5e92ba1552/system-parachains/asset-hubs/asset-hub-polkadot/src/ah_migration/mod.rs#L254-L360) is quite complex and almost every RC runtime call requires custom conversion logic. 

Note: in typescript case `origin` [does not require](https://github.com/polkadot-fellows/runtimes/blob/6048e1c18f36a9e00ea396d39b456f5e92ba1552/pallets/ah-migrator/src/referenda.rs#L379-L391) conversion, unlike Rust. I [checked](https://docs.google.com/spreadsheets/d/1gf3x7qQlFqXpXL47B54ve2QtRp4AjJsd7AXE9PxyKng/edit?usp=sharing) and `origin` is the same json structure for both AH and RC