### PR TITLE
Updated a paseo-runtimes submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,4 +8,5 @@
 	branch = ahm-tests
 [submodule "paseo-runtimes"]
 	path = paseo-runtimes
-	url = https://github.com/paseo-network/runtimes.git
+	url = https://github.com/paritytech/paseo-ahm.git
+	branch = dev-ahm


### PR DESCRIPTION
Now it points to https://github.com/paritytech/paseo-ahm `dev-ahm` branch