### PR TITLE
Added cascading process termination

### DIFF
--- a/zombie-bite-scripts/orchestrator.ts
+++ b/zombie-bite-scripts/orchestrator.ts
@@ -73,6 +73,7 @@ class Orchestrator {
             asset_hub_arg || `asset-hub:${process.env.RUNTIME_WASM}/asset_hub_polkadot_runtime.compact.compressed.wasm`,
           ],
           {
+            // The signal property tells the child process (zombie-bite) to listen for abort signals
             signal: abortController.signal,
             stdio: "inherit",
             env: {


### PR DESCRIPTION
Whenever we kill ahm orchestrator process the underlying zombie-bite process becomes a zombie and keeps running in the background. Used `AbortController` to shut down that process too