### PR TITLE
use a fixed version of papi

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/winston": "^2.4.4",
     "chokidar": "^4.0.3",
     "dotenv": "^16.4.7",
-    "polkadot-api": "^1.14.1",
+    "polkadot-api": "=1.15.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
   },


### PR DESCRIPTION
Latest version of papi `1.15.3` (released yesterday) is causing our _install_ to fail. (I already reported the [issue](https://github.com/polkadot-api/polkadot-api/issues/1111) to them). As a workaround we can _fix_ the previous version.

CI example https://github.com/paritytech/ahm-dryrun/actions/runs/16829622268/job/47673923655#step:13:12
Thx!