### PR TITLE
use .env in ci to ensure snaps have rcp ports sets

### DIFF
--- a/.github/workflows/zombie-bite-common.yml
+++ b/.github/workflows/zombie-bite-common.yml
@@ -70,6 +70,12 @@ jobs:
           AH_OVERRIDE="./runtime_wasm/asset_hub_${NETWORK}_runtime.compact.compressed.wasm"
           ls $RC_OVERRIDE
           ls $AH_OVERRIDE
+
+          # read .env to use the variable defined there (e.g ZOMBIE_BITE_RC_PORT/ZOMBIE_BITE_AH_PORT)
+          set -a
+          source .env
+          set +a
+
           zombie-bite bite -r $NETWORK --rc-override $RC_OVERRIDE --ah-override $AH_OVERRIDE -d $ZOMBIE_BITE_BASE_PATH
 
         continue-on-error: true


### PR DESCRIPTION
Small fix to ensure the produced configuration (in the snapshots) use the ports set at `.env`.

cc: @ggwpez 

Thx!

P.S: as todo, I will create a follow-up issues to re-use the new just commands.