### PR TITLE
[CI] Add 1 minute sleep before creating post migration snaps (try-run)

### DIFF
--- a/.github/workflows/zombie-bite-common.yml
+++ b/.github/workflows/zombie-bite-common.yml
@@ -161,6 +161,9 @@ jobs:
 
           echo "::endgroup::"
 
+          echo "sleeping 1 min before creating snaps"
+          sleep 60
+
           # try-runtime snap post
           echo "::group::run-try-runtime"
           try-runtime create-snapshot --uri "ws://localhost:$ALICE_PORT" "${ZOMBIE_BITE_BASE_PATH}/rc-post.snap"


### PR DESCRIPTION
Added one min sleep before creating the post-migration try-run snaps.
