### PR TITLE
run polkadot `ahm` cron ones a week

### DIFF
--- a/.github/workflows/zombie-bite.yml
+++ b/.github/workflows/zombie-bite.yml
@@ -17,6 +17,7 @@ on:
 
   schedule:
     - cron:  '0 0 * * *'
+    - cron:  '0 0 * * 0' # Only on Sundays (Polkadot)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -26,14 +27,16 @@ permissions: {}
 
 jobs:
   zombie_bite_polkadot:
-    if: ${{ inputs.network == 'ALL' || inputs.network == 'polkadot' || github.event_name == 'schedule' }}
+    # run by schedule only in Sundays or by demand
+    if: ${{ inputs.network == 'ALL' || inputs.network == 'polkadot' || github.event.schedule == '0 0 * * 0' }}
     uses: ./.github/workflows/zombie-bite-common.yml
     with:
       network: polkadot
       sudo-key: ${{ inputs.sudo-key }}
 
   zombie_bite_paseo:
-    if: ${{ inputs.network == 'ALL' || inputs.network == 'paseo' || github.event_name == 'schedule' }}
+    # run by schedule everyday or by demand
+    if: ${{ inputs.network == 'ALL' || inputs.network == 'paseo' || github.event.schedule == '0 0 * * *' }}
     uses: ./.github/workflows/zombie-bite-common.yml
     with:
       network: paseo


### PR DESCRIPTION
Since we are currently focused on _paseo_, this chnage the cron to run the `polkadot` migration ones a week (on Sunday).
Thx!

