### PR TITLE
Added a script to find RC block number to bite

### DIFF
--- a/.github/workflows/zombie-bite-common.yml
+++ b/.github/workflows/zombie-bite-common.yml
@@ -89,7 +89,12 @@ jobs:
           source .env
           set +a
 
-          zombie-bite bite -r $NETWORK --rc-override $RC_OVERRIDE --ah-override $AH_OVERRIDE -d $ZOMBIE_BITE_BASE_PATH
+          echo "::group::find-rc-block-bite"
+          RC_BITE_BLOCK=$(just find-rc-block-bite $NETWORK)
+          echo "Found RC block to bite: $RC_BITE_BLOCK"
+          echo "::endgroup::"
+
+          zombie-bite bite -r $NETWORK --rc-override $RC_OVERRIDE --ah-override $AH_OVERRIDE -d $ZOMBIE_BITE_BASE_PATH # --rc-bite-block $RC_BITE_BLOCK
 
         continue-on-error: true
 

--- a/justfile
+++ b/justfile
@@ -71,3 +71,7 @@ e2e-tests *TEST:
 compare-state base_path runtime:
     just ahm _npm-build
     npm run compare-state {{ base_path }} {{ runtime }}
+
+find-rc-block-bite network="kusama":
+    just ahm _npm-build
+    npm run find-rc-block-bite {{ network }}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "authorize-upgrade": "node dist/zombie-bite-scripts/authorize_upgrade_ah.js",
     "report-account-migration-status": "node dist/zombie-bite-scripts/report_account_migration_status.js",
     "compare-state": "node dist/migration-tests/index.js",
+    "find-rc-block-bite": "node dist/zombie-bite-scripts/find_rc_block_bite.js",
     "ahm": "node dist/zombie-bite-scripts/orchestrator.js",
     "prettier": "prettier --write .",
     "clean": "rm -rf dist",

--- a/zombie-bite-scripts/find_rc_block_bite.ts
+++ b/zombie-bite-scripts/find_rc_block_bite.ts
@@ -1,6 +1,9 @@
 import { ApiPromise, WsProvider } from '@polkadot/api';
 import { assert } from '@polkadot/util';
 
+// 500 blocks to be safe that all the tests will execute and we won't wait for the next era forever
+const OFFSET = 500;
+
 async function findFirstBlockInEra(api: ApiPromise): Promise<number> {
   // Get current active era
   const activeEra = await api.query.staking.activeEra();
@@ -62,8 +65,7 @@ async function main(network: string) {
     const block = await findFirstBlockInEra(api);
     await verifyPreviousBlockInPreviousEra(api, block);
 
-    const offset = 500; // 500 blocks to be safe that all the tests will execute and we won't wait for the next era forever
-    const rcBiteBlock = block - offset;
+    const rcBiteBlock = block - OFFSET;
 
     // output the block number to stdout so it can be captured by the workflow
     console.log(rcBiteBlock);

--- a/zombie-bite-scripts/find_rc_block_bite.ts
+++ b/zombie-bite-scripts/find_rc_block_bite.ts
@@ -1,0 +1,90 @@
+import { ApiPromise, WsProvider } from '@polkadot/api';
+import { assert } from '@polkadot/util';
+
+async function findFirstBlockInEra(api: ApiPromise): Promise<number> {
+  // Get current active era
+  const activeEra = await api.query.staking.activeEra();
+  if (activeEra.isNone) {
+    throw new Error('No active era found');
+  }
+
+  const currentEraIndex = activeEra.unwrap().index.toNumber();
+
+  const currentBlock = await api.rpc.chain.getHeader();
+  const currentBlockNumber = currentBlock.number.toNumber();
+
+  // Binary search to find first block in current era
+  let left = Math.max(0, currentBlockNumber - 14400); // Look back max 24*60*60/6 blocks (24 hours / 6 seconds per block)
+  let right = currentBlockNumber;
+  let firstBlockInEra = right;
+
+  while (left <= right) {
+    const mid = Math.floor((left + right) / 2);
+    const blockHash = await api.rpc.chain.getBlockHash(mid);
+    const apiAtBlock = await api.at(blockHash);
+    const eraAtBlock = await apiAtBlock.query.staking.activeEra();
+    
+    if (eraAtBlock.isNone) {
+      left = mid + 1;
+      continue;
+    }
+
+    const eraIndex = eraAtBlock.unwrap().index.toNumber();
+    if (eraIndex === currentEraIndex) {
+      // This block is in our target era - try looking earlier
+      firstBlockInEra = mid;
+      right = mid - 1;
+    } else if (eraIndex < currentEraIndex) {
+      // Too early - look later
+      left = mid + 1;
+    }
+  }
+
+  return firstBlockInEra;
+}
+
+async function main(network: string) {
+  const endpoints: Record<string, string> = {
+    // TODO: make a list of endpoints and retry connection if failed
+    'kusama': 'wss://kusama-rpc.polkadot.io',
+    'polkadot': 'wss://rpc.polkadot.io',
+  };
+
+  const endpoint = endpoints[network];
+  if (!endpoint) {
+    throw new Error(`Unsupported network: ${network}, supported networks are: kusama, polkadot`);
+  }
+
+  const provider = new WsProvider(endpoint);
+  const api = await ApiPromise.create({ provider });
+
+  try {
+    const block = await findFirstBlockInEra(api);
+    
+    await verifyPreviousBlockInPreviousEra(api, block);
+  } catch (error) {
+    console.error('Error:', error);
+  } finally {
+    await api.disconnect();
+  }
+}
+
+async function verifyPreviousBlockInPreviousEra(api: ApiPromise, block: number) {
+    const prevBlockHash = await api.rpc.chain.getBlockHash(block - 1);
+    const prevApiAtBlock = await api.at(prevBlockHash);
+    const prevEraAtBlock = await prevApiAtBlock.query.staking.activeEra();
+    
+    if (prevEraAtBlock.isNone) {
+      throw new Error(`Previous block ${block - 1} has no era information`);
+    }
+
+    const prevEraIndex = prevEraAtBlock.unwrap().index.toNumber();
+    const currentEraAtBlock = await api.query.staking.activeEra();
+    const currentEraIndex = currentEraAtBlock.unwrap().index.toNumber();
+
+    assert(prevEraIndex === currentEraIndex - 1, 
+      `Previous block ${block - 1} is in era ${prevEraIndex}, expected to be in era ${currentEraIndex - 1}`);
+}
+
+const network = process.argv[2] || 'kusama';
+main(network).catch(console.error);

--- a/zombie-bite-scripts/find_rc_block_bite.ts
+++ b/zombie-bite-scripts/find_rc_block_bite.ts
@@ -60,10 +60,17 @@ async function main(network: string) {
 
   try {
     const block = await findFirstBlockInEra(api);
-    
     await verifyPreviousBlockInPreviousEra(api, block);
+
+    const offset = 500; // 500 blocks to be safe that all the tests will execute and we won't wait for the next era forever
+    const rcBiteBlock = block - offset;
+
+    // output the block number to stdout so it can be captured by the workflow
+    console.log(rcBiteBlock);
+
   } catch (error) {
     console.error('Error:', error);
+    process.exit(1);
   } finally {
     await api.disconnect();
   }


### PR DESCRIPTION
The goal is to check what happens with `staking` pallet during era change.
To do that I want to be relatively close to era change. The script finds a first block in the ongoing era and creates an `offset` of `500` blocks (or 30 mins) from it. This buffer should be enough to run all the migration and PET tests that we have and not wait for too long for era change.

P.S.
I want to integrate this script into an existing (AHM all) workflow but for now zombie-bite/doppelanger does not support this option just yet.