### PR TITLE
Utility script: spawning new network, waiting for an era change, saving new network

### DIFF
--- a/justfile
+++ b/justfile
@@ -78,3 +78,7 @@ compare-state base_path runtime:
 find-rc-block-bite network="kusama":
     just ahm _npm-build
     npm run find-rc-block-bite {{ network }}
+
+make-new-snapshot base_path:
+    just ahm _npm-build
+    npm run make-new-snapshot {{ base_path }}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "report-account-migration-status": "node dist/zombie-bite-scripts/report_account_migration_status.js",
     "compare-state": "node dist/migration-tests/index.js",
     "find-rc-block-bite": "node dist/zombie-bite-scripts/find_rc_block_bite.js",
+    "make-new-snapshot": "node dist/zombie-bite-scripts/make_new_snapshot.js",
     "ahm": "node dist/zombie-bite-scripts/orchestrator.js",
     "prettier": "prettier --write .",
     "clean": "rm -rf dist",

--- a/zombie-bite-scripts/make_new_snapshot.ts
+++ b/zombie-bite-scripts/make_new_snapshot.ts
@@ -1,0 +1,62 @@
+import { ApiPromise, WsProvider } from "@polkadot/api";
+import { readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+
+// Get base path from command line args
+const basePath = process.argv[2];
+
+if (!basePath) {
+  console.error("Usage: node make_new_snapshot.js <base_path>");
+  process.exit(1);
+}
+
+async function getAHPort(basePath: string): Promise<number> {
+    try {
+      const portsFile = join(basePath, "ports.json");
+      const ports = JSON.parse(readFileSync(portsFile, 'utf8'));
+      return ports.collator_port;
+    } catch (error) {
+      console.error("Could not read ports.json, using default port 63168");
+      return 63168; // Default relay chain port
+    }
+  }
+
+async function main() {
+  // Connect to asset hub node!
+  const wsProvider = new WsProvider(`ws://127.0.0.1:63170`);
+  const api = await ApiPromise.create({ provider: wsProvider });
+
+  // Get initial era
+  const currentEra = await api.query.staking.currentEra();
+  const startingEra = currentEra.unwrap().toNumber();
+
+  console.log(`Starting era: ${startingEra}`);
+
+  // Subscribe to new blocks
+  const unsub = await api.rpc.chain.subscribeNewHeads(async () => {
+
+    const era = await api.query.staking.currentEra();
+    const currentEraNum = era.unwrap().toNumber();
+    const currentBlock = await api.rpc.chain.getBlock();
+    console.log(`Current block: ${currentBlock.block.header.number}, Era: ${currentEraNum}`);
+    
+
+    if (currentEraNum > startingEra) {
+      console.log(`Era changed from ${startingEra} to ${currentEraNum}`);
+      
+      const stopFile = join(basePath, "stop.txt"); 
+      writeFileSync(stopFile, "");
+      
+      await unsub();
+      await api.disconnect();
+      process.exit(0);
+    }
+  });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+
+

--- a/zombie-bite-scripts/make_new_snapshot.ts
+++ b/zombie-bite-scripts/make_new_snapshot.ts
@@ -16,14 +16,15 @@ async function getAHPort(basePath: string): Promise<number> {
       const ports = JSON.parse(readFileSync(portsFile, 'utf8'));
       return ports.collator_port;
     } catch (error) {
-      console.error("Could not read ports.json, using default port 63168");
-      return 63168; // Default relay chain port
+      console.error("Could not read ports.json, using default port 63170");
+      return 63170; // Default AH port
     }
   }
 
 async function main() {
   // Connect to asset hub node!
-  const wsProvider = new WsProvider(`ws://127.0.0.1:63170`);
+  const ahPort = await getAHPort(basePath);
+  const wsProvider = new WsProvider(`ws://127.0.0.1:${ahPort}`);
   const api = await ApiPromise.create({ provider: wsProvider });
 
   // Get initial era

--- a/zombie-bite-scripts/make_new_snapshot.ts
+++ b/zombie-bite-scripts/make_new_snapshot.ts
@@ -38,7 +38,8 @@ async function main() {
     const era = await api.query.staking.currentEra();
     const currentEraNum = era.unwrap().toNumber();
     const currentBlock = await api.rpc.chain.getBlock();
-    console.log(`Current block: ${currentBlock.block.header.number}, Era: ${currentEraNum}`);
+    const session = await api.query.session.currentIndex();
+    console.log(`Current block: ${currentBlock.block.header.number}, Era: ${currentEraNum}, Session: ${session.toNumber()}`);
     
 
     if (currentEraNum > startingEra) {


### PR DESCRIPTION
Terminal 1:
- `just zb spawn ./migration-run post`,
- wait until it spawns

Terminal 2:
- `just make-new-snapshot ./migration-run` - the script waits until an era changes and saves a new `stop.txt` file under `base_path` directory -- instructing Zombie-Bite to stop the network and save a new state under `post` folder, which is a new `spawn` folder
- you need to substitute `spawn` folder with a new `post` folder -- I left this step manual intentionally, it would be good if someone could take a look if script executed well,
- then run a new network with `just zb spawn ./migration-run post`. 

It will allow writing and running staking tests for [First Era After Migration](https://docs.google.com/document/d/1xiF3KwmRMa24bGrgliv6YRmFZYvaaF7OkLe2GgIxv9Q/edit?tab=t.q3ng5n5qr9o2)