### PR TITLE
no fail fast

### DIFF
--- a/.github/workflows/zombie-bite-common.yml
+++ b/.github/workflows/zombie-bite-common.yml
@@ -401,25 +401,4 @@ jobs:
           echo "**Network:** ${{ inputs.network }}" >> $GITHUB_STEP_SUMMARY
           echo "**Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
           echo "**Run:** ${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
-          
-          # Create JSON for badges
-          cat > test-results-${{ inputs.network }}.json <<EOF
-          {
-            "network": "${{ inputs.network }}",
-            "migration": "${{ steps.zombie_bite_step_spawn_and_run_migration.outcome }}",
-            "rust_tests": "${{ steps.try_runtime_rust_test.outcome }}",
-            "ts_tests": "${{ steps.ts_comparison_tests.outcome }}",
-            "pet_tests": "${{ steps.run_polkadot_ecosystem_tests.outcome }}",
-            "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-            "commit": "${{ github.sha }}",
-            "run_id": "${{ github.run_id }}"
-          }
-          EOF
-          
-      - name: upload_test_results_json
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results-${{ inputs.network }}-${{ github.sha }}
-          path: test-results-${{ inputs.network }}.json
 

--- a/.github/workflows/zombie-bite-common.yml
+++ b/.github/workflows/zombie-bite-common.yml
@@ -271,12 +271,14 @@ jobs:
             ${{ env.ZOMBIE_BITE_BASE_PATH }}/migration_done.json
 
       - name: try_runtime_rust_test
+        id: try_runtime_rust_test
         shell: bash
         env:
           NETWORK: ${{ inputs.network }}
         run: |
           export PATH=${AHM_BINS}:$PATH
           just ahm rust-test $NETWORK $ZOMBIE_BITE_BASE_PATH
+        continue-on-error: true
 
       - name: run_zombie_bite_post
         shell: bash
@@ -290,6 +292,7 @@ jobs:
         uses: ./.github/actions/wait-zb-network-ready
 
       - name: ts_comparison_tests
+        id: ts_comparison_tests
         shell: bash
         env:
           NETWORK: ${{ inputs.network }}
@@ -299,6 +302,7 @@ jobs:
           echo "::group::run-compare-state-tests"
           just compare-state ${{ env.ZOMBIE_BITE_BASE_PATH }} ${{ inputs.network }}
           echo "::endgroup::"
+        continue-on-error: true
 
       # PET
       - name: install_pet_deps
@@ -328,6 +332,7 @@ jobs:
           echo "::endgroup::"
 
       - name: run_polkadot_ecosystem_tests
+        id: run_polkadot_ecosystem_tests
         shell: bash
         env:
           ASSETHUB_BLOCK_NUMBER: ${{ env.ASSETHUB_BLOCK_NUMBER }}
@@ -351,4 +356,70 @@ jobs:
 
           yarn test assetHubKusama
           echo "::endgroup::"
+        continue-on-error: true
+
+      - name: workflow_summary
+        if: always()
+        shell: bash
+        env:
+          NETWORK: ${{ inputs.network }}
+        run: |
+          echo "## 🧟 Zombie Bite Summary for ${{ inputs.network }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Test Suite | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|------------|--------|" >> $GITHUB_STEP_SUMMARY
+          
+          # Migration status
+          if [[ "${{ steps.zombie_bite_step_spawn_and_run_migration.outcome }}" == "success" ]]; then
+            echo "| 🔄 Migration | ✅ Success |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| 🔄 Migration | ❌ Failed |" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          # Rust tests status
+          if [[ "${{ steps.try_runtime_rust_test.outcome }}" == "success" ]]; then
+            echo "| 🦀 Rust Tests | ✅ Success |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| 🦀 Rust Tests | ❌ Failed |" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          # TS comparison tests status
+          if [[ "${{ steps.ts_comparison_tests.outcome }}" == "success" ]]; then
+            echo "| 📊 TS Comparison | ✅ Success |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| 📊 TS Comparison | ❌ Failed |" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          # PET tests status
+          if [[ "${{ steps.run_polkadot_ecosystem_tests.outcome }}" == "success" ]]; then
+            echo "| 🧪 PET Tests | ✅ Success |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| 🧪 PET Tests | ❌ Failed |" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Network:** ${{ inputs.network }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Run:** ${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
+          
+          # Create JSON for badges
+          cat > test-results-${{ inputs.network }}.json <<EOF
+          {
+            "network": "${{ inputs.network }}",
+            "migration": "${{ steps.zombie_bite_step_spawn_and_run_migration.outcome }}",
+            "rust_tests": "${{ steps.try_runtime_rust_test.outcome }}",
+            "ts_tests": "${{ steps.ts_comparison_tests.outcome }}",
+            "pet_tests": "${{ steps.run_polkadot_ecosystem_tests.outcome }}",
+            "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "commit": "${{ github.sha }}",
+            "run_id": "${{ github.run_id }}"
+          }
+          EOF
+          
+      - name: upload_test_results_json
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ inputs.network }}-${{ github.sha }}
+          path: test-results-${{ inputs.network }}.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ package-lock.json
 logs/
 .claude
 zombie-bite/doppelganger/bin/
+.vscode
 
 # for local testing, it is conventional in this repo to use `migration-run-{id}` as the name of the folder; ignore it
 migration-run-*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # TL;DR [![AHM flow (all steps)](https://github.com/paritytech/ahm-dryrun/actions/workflows/zombie-bite.yml/badge.svg)](https://github.com/paritytech/ahm-dryrun/actions/workflows/zombie-bite.yml)
 
+## 🧟 Zombie Bite Test Status
+
+| Network | Workflow Status | Last Run |
+|---------|----------------|----------|
+| **Kusama** | [![Kusama AHM](https://github.com/paritytech/ahm-dryrun/actions/workflows/zombie-bite.yml/badge.svg?event=schedule)](https://github.com/paritytech/ahm-dryrun/actions/workflows/zombie-bite.yml) | Daily |
+| **Polkadot** | [![Polkadot AHM](https://github.com/paritytech/ahm-dryrun/actions/workflows/zombie-bite.yml/badge.svg?event=schedule)](https://github.com/paritytech/ahm-dryrun/actions/workflows/zombie-bite.yml) | Sundays |
+
+> 💡 **Note**: Click on the badges above to see detailed test results including Migration, Rust Tests, TS Comparison, and PET Tests status in the workflow summary.
+
 To run AHM for Kusama or Polkadot using Zombie-Bite:
 ```
 git clone --recursive git@github.com:paritytech/ahm-dryrun.git && \

--- a/README.md
+++ b/README.md
@@ -1,13 +1,20 @@
-# TL;DR [![AHM flow (all steps)](https://github.com/paritytech/ahm-dryrun/actions/workflows/zombie-bite.yml/badge.svg)](https://github.com/paritytech/ahm-dryrun/actions/workflows/zombie-bite.yml)
+# TL;DR
 
-## 🧟 Zombie Bite Test Status
+## 🧟 Test Results
 
-| Network | Workflow Status | Last Run |
-|---------|----------------|----------|
-| **Kusama** | [![Kusama AHM](https://github.com/paritytech/ahm-dryrun/actions/workflows/zombie-bite.yml/badge.svg?event=schedule)](https://github.com/paritytech/ahm-dryrun/actions/workflows/zombie-bite.yml) | Daily |
-| **Polkadot** | [![Polkadot AHM](https://github.com/paritytech/ahm-dryrun/actions/workflows/zombie-bite.yml/badge.svg?event=schedule)](https://github.com/paritytech/ahm-dryrun/actions/workflows/zombie-bite.yml) | Sundays |
+The AHM flow runs automatically:
+- **Kusama**: Daily
+- **Polkadot**: Sundays only
 
-> 💡 **Note**: Click on the badges above to see detailed test results including Migration, Rust Tests, TS Comparison, and PET Tests status in the workflow summary.
+Each workflow run tests:
+- 🔄 **Migration**: Asset Hub migration execution
+- 🦀 **Rust Tests**: Runtime verification tests
+- 📊 **TS Comparison**: State comparison tests
+- 🧪 **PET Tests**: Polkadot Ecosystem Tests
+
+**[View Latest Test Results →](https://github.com/paritytech/ahm-dryrun/actions/workflows/zombie-bite.yml)**
+
+> 💡 Click on any workflow run to see the detailed test summary table showing which tests passed or failed.
 
 To run AHM for Kusama or Polkadot using Zombie-Bite:
 ```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ## 🧟 Test Results
 
+[![AHM flow (all steps)](https://github.com/paritytech/ahm-dryrun/actions/workflows/zombie-bite.yml/badge.svg)](https://github.com/paritytech/ahm-dryrun/actions/workflows/zombie-bite.yml)
+
 The AHM flow runs automatically:
 - **Kusama**: Daily
 - **Polkadot**: Sundays only
@@ -12,7 +14,7 @@ Each workflow run tests:
 - 📊 **TS Comparison**: State comparison tests
 - 🧪 **PET Tests**: Polkadot Ecosystem Tests
 
-**[View Latest Test Results →](https://github.com/paritytech/ahm-dryrun/actions/workflows/zombie-bite.yml)**
+**[View Latest Test Results →](https://github.com/paritytech/ahm-dryrun/actions/workflows/zombie-bite.yml). See `workflow_summary` step for results of each step.**
 
 > 💡 Click on any workflow run to see the detailed test summary table showing which tests passed or failed.
 


### PR DESCRIPTION
- make it such that if one of the tests fail in the main AHM Flow run, the run won't stop.
- add `workflow_summary` which individually prints the status of:
  - migration
  - rust tests
  - PET
  - TS tests 