### PR TITLE
Custom runtime url

### DIFF
--- a/.github/workflows/zombie-bite-common.yml
+++ b/.github/workflows/zombie-bite-common.yml
@@ -108,17 +108,24 @@ jobs:
           RC_OVERRIDE="./runtime_wasm/${NETWORK}_runtime.compact.compressed.wasm"
           AH_OVERRIDE="./runtime_wasm/asset_hub_${NETWORK}_runtime.compact.compressed.wasm"
 
+          echo "::group::custom-overrides"
+
           if [[ $RC_OVERRIDE_URL != "" ]];then
             RC_OVERRIDE="/tmp/${NETWORK}_custom_runtime.compact.compressed.wasm"
             curl $RC_OVERRIDE_URL -o "/tmp/${NETWORK}_custom_rc_runtime.compact.compressed.wasm"
             echo "runtime downloaded from ${RC_OVERRIDE_URL}"
+          else
+            echo "No custom runtime for RC"
           fi;
 
           if [[ $AH_OVERRIDE_URL != "" ]];then
             RC_OVERRIDE="/tmp/${NETWORK}_custom_runtime.compact.compressed.wasm"
             curl $AH_OVERRIDE_URL -o "/tmp/${NETWORK}_custom_ah_runtime.compact.compressed.wasm"
             echo "runtime downloaded from ${AH_OVERRIDE_URL}"
+          else
+            echo "No custom runtime for AH"
           fi;
+          echo "::endgroup::"
 
           ls $RC_OVERRIDE
           ls $AH_OVERRIDE

--- a/.github/workflows/zombie-bite-common.yml
+++ b/.github/workflows/zombie-bite-common.yml
@@ -21,6 +21,10 @@ on:
         required: false
         type: string
         default: ""
+      ah_runtime_override_url:
+        required: false
+        type: string
+        default: ""
 
 env:
   ZOMBIE_BITE_BASE_PATH: "/tmp/ci"
@@ -90,6 +94,7 @@ jobs:
           NETWORK: ${{ inputs.network }}
           SUDO: ${{ inputs.sudo-key }}
           RC_OVERRIDE_URL: ${{ inputs.rc_runtime_override_url }}
+          AH_OVERRIDE_URL: ${{ inputs.ah_runtime_override_url }}
         run: |
           export PATH=${AHM_BINS}:$PATH
 
@@ -103,10 +108,16 @@ jobs:
           RC_OVERRIDE="./runtime_wasm/${NETWORK}_runtime.compact.compressed.wasm"
           AH_OVERRIDE="./runtime_wasm/asset_hub_${NETWORK}_runtime.compact.compressed.wasm"
 
-          if [[ $RC_OVERRIDE != "" ]];then
+          if [[ $RC_OVERRIDE_URL != "" ]];then
             RC_OVERRIDE="/tmp/${NETWORK}_custom_runtime.compact.compressed.wasm"
-            curl $RC_OVERRIDE_URL -o "/tmp/${NETWORK}_custom_runtime.compact.compressed.wasm"
+            curl $RC_OVERRIDE_URL -o "/tmp/${NETWORK}_custom_rc_runtime.compact.compressed.wasm"
             echo "runtime downloaded from ${RC_OVERRIDE_URL}"
+          fi;
+
+          if [[ $AH_OVERRIDE_URL != "" ]];then
+            RC_OVERRIDE="/tmp/${NETWORK}_custom_runtime.compact.compressed.wasm"
+            curl $AH_OVERRIDE_URL -o "/tmp/${NETWORK}_custom_ah_runtime.compact.compressed.wasm"
+            echo "runtime downloaded from ${AH_OVERRIDE_URL}"
           fi;
 
           ls $RC_OVERRIDE

--- a/.github/workflows/zombie-bite-common.yml
+++ b/.github/workflows/zombie-bite-common.yml
@@ -17,6 +17,10 @@ on:
         required: false
         type: string
         default: ""
+      rc_runtime_override_url:
+        required: false
+        type: string
+        default: ""
 
 env:
   ZOMBIE_BITE_BASE_PATH: "/tmp/ci"
@@ -85,6 +89,7 @@ jobs:
         env:
           NETWORK: ${{ inputs.network }}
           SUDO: ${{ inputs.sudo-key }}
+          RC_OVERRIDE_URL: ${{ inputs.rc_runtime_override_url }}
         run: |
           export PATH=${AHM_BINS}:$PATH
 
@@ -97,6 +102,13 @@ jobs:
           echo $(pwd)
           RC_OVERRIDE="./runtime_wasm/${NETWORK}_runtime.compact.compressed.wasm"
           AH_OVERRIDE="./runtime_wasm/asset_hub_${NETWORK}_runtime.compact.compressed.wasm"
+
+          if [[ $RC_OVERRIDE != "" ]];then
+            RC_OVERRIDE="/tmp/${NETWORK}_custom_runtime.compact.compressed.wasm"
+            curl $RC_OVERRIDE_URL -o "/tmp/${NETWORK}_custom_runtime.compact.compressed.wasm"
+            echo "runtime downloaded from ${RC_OVERRIDE_URL}"
+          fi;
+
           ls $RC_OVERRIDE
           ls $AH_OVERRIDE
 

--- a/.github/workflows/zombie-bite-common.yml
+++ b/.github/workflows/zombie-bite-common.yml
@@ -112,15 +112,15 @@ jobs:
 
           if [[ $RC_OVERRIDE_URL != "" ]];then
             RC_OVERRIDE="/tmp/${NETWORK}_custom_runtime.compact.compressed.wasm"
-            curl $RC_OVERRIDE_URL -o "/tmp/${NETWORK}_custom_rc_runtime.compact.compressed.wasm"
+            curl $RC_OVERRIDE_URL -o $RC_OVERRIDE
             echo "runtime downloaded from ${RC_OVERRIDE_URL}"
           else
             echo "No custom runtime for RC"
           fi;
 
           if [[ $AH_OVERRIDE_URL != "" ]];then
-            RC_OVERRIDE="/tmp/${NETWORK}_custom_runtime.compact.compressed.wasm"
-            curl $AH_OVERRIDE_URL -o "/tmp/${NETWORK}_custom_ah_runtime.compact.compressed.wasm"
+            AH_OVERRIDE="/tmp/${NETWORK}_ah_custom_runtime.compact.compressed.wasm"
+            curl $AH_OVERRIDE_URL -o $AH_OVERRIDE
             echo "runtime downloaded from ${AH_OVERRIDE_URL}"
           else
             echo "No custom runtime for AH"

--- a/.github/workflows/zombie-bite-common.yml
+++ b/.github/workflows/zombie-bite-common.yml
@@ -69,8 +69,14 @@ jobs:
         env:
           RUSTFLAGS: "-A warnings"
           NETWORK: ${{ inputs.network }}
+          RC_OVERRIDE_URL: ${{ inputs.rc_runtime_override_url }}
+          AH_OVERRIDE_URL: ${{ inputs.ah_runtime_override_url }}
         run: |
-          just build $NETWORK
+          if [[ $RC_OVERRIDE_URL == "" || $AH_OVERRIDE_URL == "" ]];then
+            just build $NETWORK
+          else
+            echo "Both RC/AH custom runtime url provided, skipping build step."
+          fi;
 
       - name: create_base_dir
         shell: bash

--- a/.github/workflows/zombie-bite.yml
+++ b/.github/workflows/zombie-bite.yml
@@ -19,6 +19,11 @@ on:
         required: false
         type: string
         default: ""
+      ah_runtime_override_url:
+        description: "An url to download the AH runtime to override"
+        required: false
+        type: string
+        default: ""
   schedule:
     - cron: "0 0 * * *" # Every Day for Kusama
     - cron: "0 0 * * 0" # Only on Sundays for Polkadot
@@ -38,6 +43,7 @@ jobs:
       network: polkadot
       sudo-key: ${{ inputs.sudo-key }}
       rc_runtime_override_url: ${{ inputs.rc_runtime_override_url }}
+      ah_runtime_override_url: ${{ inputs.ah_runtime_override_url }}
       runner: parity-large-persistent-test
 
   zombie_bite_kusama:
@@ -48,6 +54,7 @@ jobs:
       network: kusama
       sudo-key: ${{ inputs.sudo-key }}
       rc_runtime_override_url: ${{ inputs.rc_runtime_override_url }}
+      ah_runtime_override_url: ${{ inputs.ah_runtime_override_url }}
       runner: parity-large-persistent-test
 
   # Paseo migration disabled (already done)

--- a/.github/workflows/zombie-bite.yml
+++ b/.github/workflows/zombie-bite.yml
@@ -37,6 +37,7 @@ jobs:
     with:
       network: polkadot
       sudo-key: ${{ inputs.sudo-key }}
+      rc_runtime_override_url: ${{ inputs.rc_runtime_override_url }}
       runner: parity-large-persistent-test
 
   zombie_bite_kusama:
@@ -46,6 +47,7 @@ jobs:
     with:
       network: kusama
       sudo-key: ${{ inputs.sudo-key }}
+      rc_runtime_override_url: ${{ inputs.rc_runtime_override_url }}
       runner: parity-large-persistent-test
 
   # Paseo migration disabled (already done)

--- a/.github/workflows/zombie-bite.yml
+++ b/.github/workflows/zombie-bite.yml
@@ -15,12 +15,12 @@ on:
           - kusama
           - polkadot
       rc_runtime_override_url:
-        description: "An url to download the RC runtime to override"
+        description: "An url to download the RC runtime to override (e.g https://some-server.com/kusama_runtime-v1009000.compact.compressed_processed.wasm)"
         required: false
         type: string
         default: ""
       ah_runtime_override_url:
-        description: "An url to download the AH runtime to override"
+        description: "An url to download the AH runtime to override (e.g https://some-server.com/asset-hub-kusama_runtime-v1009000.compact.compressed_processed.wasm)"
         required: false
         type: string
         default: ""

--- a/.github/workflows/zombie-bite.yml
+++ b/.github/workflows/zombie-bite.yml
@@ -14,7 +14,11 @@ on:
           - ALL
           - kusama
           - polkadot
-
+      rc_runtime_override_url:
+        description: "An url to download the RC runtime to override"
+        required: false
+        type: string
+        default: ""
   schedule:
     - cron: "0 0 * * *" # Every Day for Kusama
     - cron: "0 0 * * 0" # Only on Sundays for Polkadot


### PR DESCRIPTION
Add two more inputs to AHM Flow, to allow to pass a url to download the runtimes to use and easily test runtimes without updating the submodule.

- rc_runtime_override_url
- ah_runtime_override_url

If both are provided the build step is skipped.

Thx!