### PR TITLE
Allow logs in runtimes

### DIFF
--- a/.github/workflows/zombie-bite-common.yml
+++ b/.github/workflows/zombie-bite-common.yml
@@ -146,6 +146,12 @@ jobs:
           echo "Found RC block to bite: $RC_BITE_BLOCK"
           echo "::endgroup::"
 
+          export RUST_LOG_RC=$ZOMBIE_BITE_RUST_LOG
+          export RUST_LOG_COL=$ZOMBIE_BITE_RUST_LOG_COL
+
+          echo "RUST_LOG_RC: $RUST_LOG_RC"
+          echo "RUST_LOG_COL: $RUST_LOG_COL"
+
           # TODO: add ones we support this in zombie-bite
           # --rc-bite-block $RC_BITE_BLOCK
           zombie-bite bite -r $NETWORK --rc-override $RC_OVERRIDE --ah-override $AH_OVERRIDE -d $ZOMBIE_BITE_BASE_PATH

--- a/justfile
+++ b/justfile
@@ -51,10 +51,11 @@ build runtime:
     mkdir -p ./runtime_wasm
 
     if [ "{{ runtime }}" = "polkadot" ]; then
-        cd ${RUNTIMES_PATH} && ${CARGO_CMD} build --profile production --features on-chain-release-build,polkadot-ahm -p asset-hub-polkadot-runtime -p polkadot-runtime && cd ..
+        # only enable `metadata-hash`, but not `on-chain-release-build` to still have logs enabled.
+        cd ${RUNTIMES_PATH} && ${CARGO_CMD} build --profile production --features metadata-hash,polkadot-ahm -p asset-hub-polkadot-runtime -p polkadot-runtime && cd ..
         cp ${RUNTIMES_PATH}/target/production/wbuild/**/**.compact.compressed.wasm ./runtime_wasm/
     elif [ "{{ runtime }}" = "kusama" ]; then
-        # features was using on-chain-release-build
+        # only enable `metadata-hash`, but not `on-chain-release-build` to still have logs enabled.
         cd ${RUNTIMES_PATH} && ${CARGO_CMD} build --profile production --features metadata-hash,kusama-ahm -p asset-hub-kusama-runtime -p staging-kusama-runtime && cd ..
         cp ${RUNTIMES_PATH}/target/production/wbuild/**/**.compact.compressed.wasm ./runtime_wasm/
         # rename staging_kusama_runtime.compact.compressed.wasm to kusama_runtime.compact.compressed.wasm for naming convention compatibility

--- a/justfile
+++ b/justfile
@@ -54,7 +54,8 @@ build runtime:
         cd ${RUNTIMES_PATH} && ${CARGO_CMD} build --profile production --features on-chain-release-build,polkadot-ahm -p asset-hub-polkadot-runtime -p polkadot-runtime && cd ..
         cp ${RUNTIMES_PATH}/target/production/wbuild/**/**.compact.compressed.wasm ./runtime_wasm/
     elif [ "{{ runtime }}" = "kusama" ]; then
-        cd ${RUNTIMES_PATH} && ${CARGO_CMD} build --profile production --features on-chain-release-build,kusama-ahm -p asset-hub-kusama-runtime -p staging-kusama-runtime && cd ..
+        # features was using on-chain-release-build
+        cd ${RUNTIMES_PATH} && ${CARGO_CMD} build --profile production --features metadata-hash,kusama-ahm -p asset-hub-kusama-runtime -p staging-kusama-runtime && cd ..
         cp ${RUNTIMES_PATH}/target/production/wbuild/**/**.compact.compressed.wasm ./runtime_wasm/
         # rename staging_kusama_runtime.compact.compressed.wasm to kusama_runtime.compact.compressed.wasm for naming convention compatibility
         mv ./runtime_wasm/staging_kusama_runtime.compact.compressed.wasm ./runtime_wasm/kusama_runtime.compact.compressed.wasm


### PR DESCRIPTION
ping @ggwpez this pr change the _build_ command to not include the `on-chain-release-build` in order to not disable the logs in the runtime. Do we need to make the test with this feature on?

Thx!!

cc: @kianenigma 