### PR TITLE
Add a test to validate all events during a whole staking era

### DIFF
--- a/.github/workflows/era-events-test-common.yml
+++ b/.github/workflows/era-events-test-common.yml
@@ -1,0 +1,94 @@
+name: Era Events Test Common
+on:
+  workflow_call:
+    inputs:
+      network:
+        type: string
+        required: false
+        default: 'kusama'
+      run-id:
+        type: string
+        description: "run-id of the artifacts to download"
+        required: true
+
+env:
+  ZOMBIE_BITE_BASE_PATH: ${{ github.workspace }}/migration-run
+
+jobs:
+  era-events-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: extractions/setup-just@v2
+
+      - name: download_post_migration_db
+        uses: ./.github/actions/download-artifact
+        env:
+          RUN_ID: ${{ inputs.run-id }}
+          GH_TOKEN: ${{ github.token }}
+          NETWORK: ${{ inputs.network }}
+        with:
+          gh-token: ${{ env.GH_TOKEN }}
+          destination-path: ${{ env.ZOMBIE_BITE_BASE_PATH }}
+          run-id: ${{ env.RUN_ID }}
+          name-pattern: "${{ env.NETWORK }}-post-migration-db-*"
+
+      - name: download_doppelganger_binaries
+        uses: ./.github/actions/download-doppelganger-binaries
+        with:
+          destination-path: ${{ env.ZOMBIE_BITE_BASE_PATH }}
+
+      - name: install_zombie_bite
+        shell: bash
+        run: |
+          just install-zombie-bite
+
+      - name: verify_artifact
+        shell: bash
+        run: |
+          echo "::group::Artifact contents"
+          ls -la "$ZOMBIE_BITE_BASE_PATH" || true
+          ls -la "$ZOMBIE_BITE_BASE_PATH/spawn" || true
+          echo "::endgroup::"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: npm_install_and_build
+        shell: bash
+        run: |
+          npm install
+          npm run build
+
+      - name: run_zombie_bite_spawn
+        shell: bash
+        env:
+          BASE_PATH: ${{ env.ZOMBIE_BITE_BASE_PATH }}
+        run: |
+          export PATH="${BASE_PATH}:$PATH"
+          nohup just zb spawn $ZOMBIE_BITE_BASE_PATH > nohup.out 2>&1 &
+
+      - name: wait_for_network
+        uses: ./.github/actions/wait-zb-network-ready
+
+      - name: run_era_events_test
+        shell: bash
+        timeout-minutes: 30
+        env:
+          BASE_PATH: ${{ env.ZOMBIE_BITE_BASE_PATH }}
+          NETWORK: ${{ inputs.network }}
+        run: |
+          echo "Running era events test..."
+          just ahm era-events-test $BASE_PATH $NETWORK
+
+      - name: upload_logs_on_failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: era-events-test-logs-${{ inputs.network }}-${{ github.sha }}
+          path: |
+            nohup.out
+            ${{ env.ZOMBIE_BITE_BASE_PATH }}/spawn-debug/**/*.log

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -7,7 +7,7 @@ on:
         required: false
       network:
         description: "network to use, default kusama"
-        default: 'kusama'
+        default: "kusama"
         type: choice
         options:
           - kusama
@@ -60,3 +60,22 @@ jobs:
       run-id: ${{ inputs.run-id }}
       network: ${{ inputs.network }}
 
+  # TODO: Create dedicated CI job that spawns post-migration network, lets it run for a
+  # complete era (e.g., 2*14400 blocks), then saves the database as an artifact.
+  # This ensures we always have databases with full era history for testing.
+  # For now, using hardcoded run-id from a known good run with full era data.
+  era-events-test-kusama:
+    if: ${{ inputs.network == 'kusama' }}
+    uses: ./.github/workflows/era-events-test-common.yml
+    with:
+      # TODO: Replace with run-id from dedicated long-running CI job
+      run-id: "TBD"
+      network: kusama
+
+  era-events-test-polkadot:
+    if: ${{ inputs.network == 'polkadot' }}
+    uses: ./.github/workflows/era-events-test-common.yml
+    with:
+      # TODO: Replace with run-id from dedicated long-running CI job
+      run-id: "TBD"
+      network: polkadot

--- a/justfiles/ahm.justfile
+++ b/justfiles/ahm.justfile
@@ -146,3 +146,10 @@ rust-test runtime base_path:
       --features {{ runtime }}-ahm \
       --features try-runtime \
       post_migration_checks_only -- --include-ignored --nocapture --test-threads 1
+
+# Run era events test with archive mode databases from zombie-bite
+# Requires: zombie-bite databases in <network>/db/full structure
+# Example: just ahm era-events-test ./polkadot-era-test polkadot
+era-events-test base_path network="polkadot":
+    just ahm _npm-build
+    node dist/zombie-bite-scripts/run_era_events_test.js {{ base_path }} {{ network }}

--- a/migration-tests/era-events-runner.ts
+++ b/migration-tests/era-events-runner.ts
@@ -1,0 +1,108 @@
+import "@polkadot/api-augment";
+import "@polkadot/types-augment";
+import { ApiPromise, WsProvider } from "@polkadot/api";
+import { logger } from "../shared/logger.js";
+import { eraEventsTest } from "./pallets/staking/era_events.js";
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Runner for era events tests using zombie-bite spawned networks
+ *
+ * This test expects zombie-bite spawn to be already running with the
+ * extracted databases from the CI artifact containing enough blocks to accommodate a whole era.
+ *
+ * The test will:
+ * 1. Read ports from ports.json
+ * 2. Connect to running RC and AH nodes via WebSocket
+ * 3. Find era start by searching backwards through block history
+ * 4. Collect and validate all events from era start to era end
+ */
+
+type Network = "kusama" | "polkadot";
+
+interface Ports {
+  alice_port: number;
+  collator_port: number;
+}
+
+/**
+ * Read ports from zombie-bite ports.json file
+ */
+function readPorts(basePath: string): Ports {
+  const portsFile = join(basePath, "ports.json");
+
+  if (!existsSync(portsFile)) {
+    throw new Error(
+      `Ports file not found: ${portsFile}\n` +
+        `Make sure zombie-bite spawn is running in ${basePath}`,
+    );
+  }
+
+  try {
+    const portsData = JSON.parse(readFileSync(portsFile, "utf8"));
+    return {
+      alice_port: portsData.alice_port,
+      collator_port: portsData.collator_port,
+    };
+  } catch (error) {
+    throw new Error(`Failed to read ports.json: ${error}`);
+  }
+}
+
+/**
+ * Run era events test by connecting to zombie-bite spawned network
+ *
+ * @param basePath - Directory containing ports.json and zombie-bite spawn artifacts
+ * @param network - Network name (kusama or polkadot)
+ */
+export async function runEraEventsTest(
+  basePath: string,
+  network: Network = "kusama",
+): Promise<boolean> {
+  logger.info("Starting era events test (zombie-bite spawn mode)", {
+    basePath,
+    network,
+  });
+
+  const ports = readPorts(basePath);
+  logger.info("Connecting to zombie-bite network", {
+    rc_port: ports.alice_port,
+    ah_port: ports.collator_port,
+  });
+
+  const rcProvider = new WsProvider(`ws://127.0.0.1:${ports.alice_port}`);
+  const rcApi = await ApiPromise.create({ provider: rcProvider });
+
+  const ahProvider = new WsProvider(`ws://127.0.0.1:${ports.collator_port}`);
+  const ahApi = await ApiPromise.create({ provider: ahProvider });
+
+  try {
+    logger.info("✅ Connected to both chains");
+
+    const context = {
+      pre: {
+        rc_api_before: rcApi,
+        ah_api_before: ahApi,
+      },
+      post: {
+        rc_api_after: rcApi,
+        ah_api_after: ahApi,
+      },
+    };
+
+    logger.info("Running era events validation...");
+    const pre_payload = await eraEventsTest.pre_check(context.pre);
+    await eraEventsTest.post_check(context.post, pre_payload);
+
+    logger.info(`✅ Era events test completed successfully`);
+    return true;
+  } catch (error) {
+    logger.error(`❌ Era events test failed:`, error);
+    return false;
+  } finally {
+    logger.info("Disconnecting from nodes...");
+    await rcApi.disconnect();
+    await ahApi.disconnect();
+  }
+}

--- a/migration-tests/pallets/staking/era_events.ts
+++ b/migration-tests/pallets/staking/era_events.ts
@@ -1,0 +1,758 @@
+import "@polkadot/api-augment";
+import {
+  MigrationTest,
+  PostCheckContext,
+  PreCheckContext,
+  PreCheckResult,
+} from "../../types.js";
+import assert from "assert";
+import { logger } from "../../../shared/logger.js";
+
+/**
+ * Era Events Validation Test
+ *
+ * This test operates ENTIRELY in post-migration state. Unlike other MigrationTest
+ * implementations where "before" = pre-migration and "after" = post-migration,
+ * here both "before" and "after" are post-migration:
+ *
+ * - pre_check (rc_api_before, ah_api_before):
+ *   APIs loaded from archive snapshots at era end
+ *   Finds the start of era X by searching backwards through the archive
+ *
+ * - post_check (rc_api_after, ah_api_after):
+ *   Same APIs (still era end snapshots)
+ *   Validates events from era start to era end
+ */
+interface EventRecord {
+  blockNumber: number;
+  section: string;
+  method: string;
+  data: any;
+}
+
+interface PhaseTransitionRecord {
+  phase: string;
+  blockNumber: number;
+  fromPhase: string;
+}
+
+interface FilteredRCEvents {
+  sessionNewSession: EventRecord[];
+  validatorSetReceived: EventRecord[];
+}
+
+interface FilteredAHEvents {
+  sessionRotated: EventRecord[];
+  sessionReportReceived: EventRecord[];
+  phaseTransitioned: EventRecord[];
+  signedRegistered: EventRecord[];
+  signedStored: EventRecord[];
+  verifierVerified: EventRecord[];
+  verifierQueued: EventRecord[];
+  signedRewarded: EventRecord[];
+  pagedElectionProceeded: EventRecord[];
+  eraPaid: EventRecord[];
+}
+
+type Network = "kusama" | "polkadot";
+
+async function getBlockNumber(api: any): Promise<number> {
+  const header = await api.rpc.chain.getHeader();
+  return header.number.toNumber();
+}
+
+async function getCurrentEra(api: any): Promise<number | undefined> {
+  const currentEraOpt = await api.query.staking.currentEra();
+  return currentEraOpt.isSome ? currentEraOpt.unwrap().toNumber() : undefined;
+}
+
+async function collectEventsBetween(
+  api: any,
+  startBlock: number,
+  endBlock: number,
+): Promise<EventRecord[]> {
+  const allEvents: EventRecord[] = [];
+
+  logger.info(`Collecting events from block ${startBlock} to ${endBlock}...`);
+
+  // Query events for each block in range
+  for (let blockNum = startBlock; blockNum <= endBlock; blockNum++) {
+    try {
+      const blockHash = await api.rpc.chain.getBlockHash(blockNum);
+      const apiAt = await api.at(blockHash);
+      const events = await apiAt.query.system.events();
+
+      for (const record of events) {
+        allEvents.push({
+          blockNumber: blockNum,
+          section: record.event.section,
+          method: record.event.method,
+          data: record.event.data.toJSON(),
+        });
+      }
+    } catch (error) {
+      logger.warn(`Failed to collect events at block ${blockNum}: ${error}`);
+    }
+  }
+
+  logger.info(
+    `Collected ${allEvents.length} events from ${endBlock - startBlock + 1} blocks`,
+  );
+
+  return allEvents;
+}
+
+async function detectNetwork(api: any): Promise<Network> {
+  const chainName = (await api.rpc.system.chain()).toString().toLowerCase();
+
+  if (chainName.includes("kusama")) return "kusama";
+  if (chainName.includes("polkadot")) return "polkadot";
+
+  // For Asset Hub chains
+  if (chainName.includes("asset-hub-kusama") || chainName.includes("statemine"))
+    return "kusama";
+  if (
+    chainName.includes("asset-hub-polkadot") ||
+    chainName.includes("statemint")
+  )
+    return "polkadot";
+
+  throw new Error(
+    `Unsupported network: ${chainName}. Only kusama and polkadot are supported.`,
+  );
+}
+
+async function getRuntimePageCount(
+  api: any,
+  network: Network,
+): Promise<number> {
+  // Try to query from runtime constants
+  try {
+    const pages = api.consts.multiBlockElection?.pages;
+    if (pages) {
+      return pages.toNumber();
+    }
+  } catch (e) {
+    throw new Error(
+      `Failed to query runtime constant multiBlockElection.pages for ${network}: ${e}`,
+    );
+  }
+
+  throw new Error(
+    `Runtime constant multiBlockElection.pages not found for ${network}`,
+  );
+}
+
+/**
+ * Find era start block by searching backwards through archive
+ *
+ * Searches for SessionRotated event where:
+ * - active_era = currentEra - 1
+ * - planned_era = currentEra
+ *
+ * This marks the beginning of era preparation for currentEra.
+ */
+async function findEraStartBlock(api: any, chainName: string): Promise<number> {
+  const endBlock = await getBlockNumber(api);
+  const currentEra = await getCurrentEra(api);
+
+  if (!currentEra) {
+    throw new Error("Could not determine current era");
+  }
+
+  logger.info(
+    `${chainName}: Searching backwards from block ${endBlock} for era ${currentEra} start...`,
+  );
+
+  const archiveSize = 2 * 14400;
+  const startSearchBlock = Math.max(1, endBlock - archiveSize);
+
+  // Search backwards through archive
+  for (let blockNum = endBlock; blockNum >= startSearchBlock; blockNum--) {
+    try {
+      const blockHash = await api.rpc.chain.getBlockHash(blockNum);
+      const apiAt = await api.at(blockHash);
+      const events = await apiAt.query.system.events();
+
+      // Find SessionRotated that marks era start
+      for (const record of events) {
+        if (
+          record.event.section === "staking" &&
+          record.event.method === "SessionRotated"
+        ) {
+          const data = record.event.data.toJSON() as any;
+          const activeEra = data.activeEra;
+          const plannedEra = data.plannedEra;
+
+          // Found era start: previous era was active, current era is planned
+          if (activeEra === currentEra - 1 && plannedEra === currentEra) {
+            logger.info(
+              `${chainName}: ✅ Found era ${currentEra} start at block ${blockNum} ` +
+                `(SessionRotated: active_era=${activeEra}, planned_era=${plannedEra})`,
+            );
+            return blockNum;
+          }
+        }
+      }
+    } catch (error) {
+      // Continue searching if block query fails
+    }
+  }
+
+  throw new Error(
+    `${chainName}: Could not find era ${currentEra} start in archive window ` +
+      `(searched blocks ${startSearchBlock} to ${endBlock})`,
+  );
+}
+
+function filterRCEvents(events: EventRecord[]): FilteredRCEvents {
+  return {
+    sessionNewSession: events.filter(
+      (e) => e.section === "session" && e.method === "NewSession",
+    ),
+    validatorSetReceived: events.filter(
+      (e) =>
+        e.section === "stakingAhClient" && e.method === "ValidatorSetReceived",
+    ),
+  };
+}
+
+function filterAHEvents(events: EventRecord[]): FilteredAHEvents {
+  return {
+    sessionRotated: events.filter(
+      (e) => e.section === "staking" && e.method === "SessionRotated",
+    ),
+    sessionReportReceived: events.filter(
+      (e) =>
+        e.section === "stakingRcClient" && e.method === "SessionReportReceived",
+    ),
+    phaseTransitioned: events.filter(
+      (e) =>
+        e.section === "multiBlockElection" && e.method === "PhaseTransitioned",
+    ),
+    signedRegistered: events.filter(
+      (e) =>
+        e.section === "multiBlockElectionSigned" && e.method === "Registered",
+    ),
+    signedStored: events.filter(
+      (e) => e.section === "multiBlockElectionSigned" && e.method === "Stored",
+    ),
+    verifierVerified: events.filter(
+      (e) =>
+        e.section === "multiBlockElectionVerifier" && e.method === "Verified",
+    ),
+    verifierQueued: events.filter(
+      (e) =>
+        e.section === "multiBlockElectionVerifier" && e.method === "Queued",
+    ),
+    signedRewarded: events.filter(
+      (e) =>
+        e.section === "multiBlockElectionSigned" && e.method === "Rewarded",
+    ),
+    pagedElectionProceeded: events.filter(
+      (e) => e.section === "staking" && e.method === "PagedElectionProceeded",
+    ),
+    eraPaid: events.filter(
+      (e) => e.section === "staking" && e.method === "EraPaid",
+    ),
+  };
+}
+
+function extractPhaseName(phaseData: any): string {
+  // Handle phase data like: { Snapshot: 4 } or { Signed: 0 } or "Off"
+  if (typeof phaseData === "string") return phaseData;
+  if (typeof phaseData === "object" && phaseData !== null) {
+    const keys = Object.keys(phaseData);
+    return keys.length > 0 ? keys[0] : "Unknown";
+  }
+  return "Unknown";
+}
+
+function findSessionRotatedWithPlannedEra(
+  events: EventRecord[],
+): EventRecord | undefined {
+  return events.find((e) => {
+    const activeEra = e.data.activeEra;
+    const plannedEra = e.data.plannedEra;
+    return activeEra !== undefined && plannedEra === activeEra + 1;
+  });
+}
+
+function validatePhaseOrdering(transitions: PhaseTransitionRecord[]): void {
+  // Expected order
+  const expectedOrder = [
+    "Snapshot",
+    "Signed",
+    "SignedValidation",
+    "Unsigned",
+    "Done",
+    "Export",
+    "Off",
+  ];
+
+  let lastIndex = -1;
+  for (const transition of transitions) {
+    const currentIndex = expectedOrder.indexOf(transition.phase);
+
+    assert(
+      currentIndex > lastIndex,
+      `Phase '${transition.phase}' appears out of order. ` +
+        `Expected index ${currentIndex} to be > ${lastIndex}`,
+    );
+
+    lastIndex = currentIndex;
+  }
+}
+
+function validatePhaseTransitions(
+  events: EventRecord[],
+  afterBlock: number,
+): PhaseTransitionRecord[] {
+  const relevantEvents = events.filter((e) => e.blockNumber > afterBlock);
+
+  const expectedPhases = [
+    "Snapshot",
+    "Signed",
+    "SignedValidation",
+    "Unsigned",
+    "Done",
+    "Export",
+    "Off",
+  ];
+
+  const transitions: PhaseTransitionRecord[] = [];
+  let lastBlockNumber = afterBlock;
+  let lastPhase: string | null = null;
+
+  for (const event of relevantEvents) {
+    const toPhase = extractPhaseName(event.data.to);
+    const fromPhase = extractPhaseName(event.data.from);
+
+    if (expectedPhases.includes(toPhase)) {
+      assert(
+        event.blockNumber > lastBlockNumber,
+        `Phase transition to ${toPhase} at block ${event.blockNumber} ` +
+          `must be > previous phase at block ${lastBlockNumber}`,
+      );
+    }
+
+    transitions.push({
+      phase: toPhase,
+      blockNumber: event.blockNumber,
+      fromPhase: fromPhase,
+    });
+
+    lastBlockNumber = event.blockNumber;
+    lastPhase = toPhase;
+  }
+
+  for (const required of expectedPhases) {
+    assert(
+      transitions.some((t) => t.phase === required),
+      `Required phase '${required}' not found in transitions`,
+    );
+  }
+
+  validatePhaseOrdering(transitions);
+
+  return transitions;
+}
+
+function validateSignedPhase(
+  registered: EventRecord[],
+  stored: EventRecord[],
+  rewarded: EventRecord[],
+): void {
+  // Must have at least one score registered
+  assert(
+    registered.length > 0,
+    "Must have at least one score registered in Signed phase",
+  );
+
+  // Must have pages stored
+  assert(stored.length > 0, "Must have pages stored in Signed phase");
+
+  assert(
+    rewarded.length > 0,
+    "Miner must be rewarded for successful solution submission. " +
+      "Expected MultiBlockElectionSigned.Rewarded event.",
+  );
+
+  const rewardEvent = rewarded[0];
+  assert(
+    rewardEvent.data.field_2 !== undefined &&
+      BigInt(rewardEvent.data.field_2) > 0n,
+    `Reward amount must be > 0, got ${rewardEvent.data.field_2}`,
+  );
+
+  const pageIndices = stored
+    .map((e) => e.data.field_2)
+    .sort((a: number, b: number) => a - b);
+
+  for (let i = 0; i < pageIndices.length; i++) {
+    assert(
+      pageIndices[i] === i,
+      `Expected page index ${i} but got ${pageIndices[i]}. ` +
+        `Pages must be stored sequentially starting from 0.`,
+    );
+  }
+}
+
+function validateSignedValidationPhase(
+  verified: EventRecord[],
+  queued: EventRecord[],
+  storedPageCount: number,
+): void {
+  // Each page should be verified
+  assert(
+    verified.length > 0,
+    "Pages must be verified in SignedValidation phase",
+  );
+
+  assert(
+    verified.length === storedPageCount,
+    `Number of verified pages (${verified.length}) must match ` +
+      `number of stored pages (${storedPageCount})`,
+  );
+
+  assert(queued.length > 0, "Solution must be queued after verification");
+}
+
+async function validateExportPhase(
+  pagedElectionProceeded: EventRecord[],
+  ahApi: any,
+  network: Network,
+): Promise<void> {
+  const expectedPageCount = await getRuntimePageCount(ahApi, network);
+
+  assert(
+    pagedElectionProceeded.length > 0,
+    "Must have PagedElectionProceeded events in Export phase",
+  );
+
+  assert(
+    pagedElectionProceeded.length === expectedPageCount,
+    `Export phase must produce exactly ${expectedPageCount} PagedElectionProceeded events ` +
+      `(${network} config), but got ${pagedElectionProceeded.length}`,
+  );
+
+  // Validate eras_elected decrements correctly
+  const erasElected = pagedElectionProceeded.map((e) => e.data.eras_elected);
+
+  for (let i = 1; i < erasElected.length; i++) {
+    const prev = erasElected[i - 1];
+    const curr = erasElected[i];
+
+    // Each should be less than or equal to previous
+    assert(
+      curr <= prev,
+      `eras_elected should not increase: at index ${i - 1} was ${prev}, at ${i} is ${curr}`,
+    );
+  }
+}
+
+function validateValidatorSetPropagation(
+  validatorSetReceived: EventRecord[],
+  pagedElectionProceeded: EventRecord[],
+): void {
+  assert(
+    validatorSetReceived.length > 0,
+    "RC must receive validator set from AH",
+  );
+
+  const lastExport = Math.max(
+    ...pagedElectionProceeded.map((e) => e.blockNumber),
+  );
+  const firstReceived = Math.min(
+    ...validatorSetReceived.map((e) => e.blockNumber),
+  );
+
+  assert(
+    lastExport > 0 && firstReceived > 0,
+    "Both validator set export and reception must occur",
+  );
+}
+
+function validateSessionQueuing(
+  sessionNewSession: EventRecord[],
+  validatorSetReceived: EventRecord[],
+): void {
+  const lastValidatorSet = Math.max(
+    ...validatorSetReceived.map((e) => e.blockNumber),
+  );
+  const sessionsAfter = sessionNewSession.filter(
+    (e) => e.blockNumber >= lastValidatorSet,
+  );
+
+  assert(
+    sessionsAfter.length > 0,
+    "Should see NewSession on RC after ValidatorSetReceived",
+  );
+}
+
+function validateActivationTimestamp(
+  sessionReportReceived: EventRecord[],
+): void {
+  // Find a SessionReportReceived with activation_timestamp set
+  const withActivation = sessionReportReceived.find((e) => {
+    const timestamp = e.data.activationTimestamp;
+    return (
+      timestamp !== null && timestamp !== undefined && timestamp !== "None"
+    );
+  });
+
+  assert(
+    withActivation !== undefined,
+    "Must receive SessionReportReceived with activation_timestamp set",
+  );
+}
+
+function validateEraPaid(eraPaid: EventRecord[], expectedEra: number): void {
+  // Must have EraPaid event
+  assert(eraPaid.length > 0, "Must have EraPaid event for era rotation");
+
+  // Validate era index
+  const eraPaidEvent = eraPaid[0];
+  assert(
+    eraPaidEvent.data.eraIndex !== undefined,
+    "EraPaid must include era index",
+  );
+
+  // TODO: Validate payout amounts are reasonable
+  const validatorPayout = BigInt(eraPaidEvent.data.validatorPayout || 0);
+  assert(
+    validatorPayout > 0n,
+    `EraPaid validator payout must be > 0, got ${validatorPayout}`,
+  );
+}
+
+function validateFinalSessionRotated(
+  sessionRotated: EventRecord[],
+  expectedActiveEra: number,
+): void {
+  // Find final SessionRotated with active_era = expected
+  const finalRotation = sessionRotated.find(
+    (e) => e.data.activeEra === expectedActiveEra,
+  );
+
+  assert(
+    finalRotation !== undefined,
+    `Must find final SessionRotated with active_era=${expectedActiveEra}`,
+  );
+}
+
+function logValidationSummary(
+  phaseTransitions: PhaseTransitionRecord[],
+  ahFiltered: FilteredAHEvents,
+  network: Network,
+  storedPageCount: number,
+): void {
+  logger.info("✅ Era events validation summary:", {
+    network,
+    phaseTransitions: phaseTransitions.map((t) => ({
+      phase: t.phase,
+      block: t.blockNumber,
+    })),
+    signedScores: ahFiltered.signedRegistered.length,
+    signedPages: storedPageCount,
+    verifiedPages: ahFiltered.verifierVerified.length,
+    exportedPages: ahFiltered.pagedElectionProceeded.length,
+    rewardEvents: ahFiltered.signedRewarded.length,
+    queuedEvents: ahFiltered.verifierQueued.length,
+  });
+}
+
+async function validateEraEventSequence(
+  rcEvents: EventRecord[],
+  ahEvents: EventRecord[],
+  prePayload: PreCheckResult,
+  ahApi: any,
+  network: Network,
+): Promise<void> {
+  const rcFiltered = filterRCEvents(rcEvents);
+  const ahFiltered = filterAHEvents(ahEvents);
+
+  logger.info("Starting era event sequence validation...");
+
+  // Step 1: Find SessionRotated with active_era=x and planned_era=x+1
+  const startingSessionRotated = findSessionRotatedWithPlannedEra(
+    ahFiltered.sessionRotated,
+  );
+  assert(
+    startingSessionRotated !== undefined,
+    "Must find SessionRotated with active_era=x and planned_era=x+1",
+  );
+
+  const activeEra = startingSessionRotated.data.activeEra;
+  const plannedEra = startingSessionRotated.data.plannedEra;
+  assert(
+    plannedEra === activeEra + 1,
+    `Planned era ${plannedEra} should be active era ${activeEra} + 1`,
+  );
+
+  logger.info(
+    `✅ Found SessionRotated with active_era=${activeEra}, planned_era=${plannedEra}`,
+  );
+
+  // Step 2: Validate phase transitions
+  const phaseTransitions = validatePhaseTransitions(
+    ahFiltered.phaseTransitioned,
+    startingSessionRotated.blockNumber,
+  );
+
+  logger.info(
+    `✅ Phase transitions validated: ${phaseTransitions.map((t) => t.phase).join(" → ")}`,
+  );
+
+  // Step 3: Validate Signed phase (score + pages + reward)
+  validateSignedPhase(
+    ahFiltered.signedRegistered,
+    ahFiltered.signedStored,
+    ahFiltered.signedRewarded,
+  );
+
+  const storedPageCount = ahFiltered.signedStored.length;
+  logger.info(
+    `✅ Signed phase: ${ahFiltered.signedRegistered.length} scores, ${storedPageCount} pages, ${ahFiltered.signedRewarded.length} rewards`,
+  );
+
+  // Step 4: Validate SignedValidation phase
+  validateSignedValidationPhase(
+    ahFiltered.verifierVerified,
+    ahFiltered.verifierQueued,
+    storedPageCount,
+  );
+
+  logger.info(
+    `✅ Validation phase: ${ahFiltered.verifierVerified.length} pages verified, solution queued`,
+  );
+
+  // Step 5: Validate Export phase
+  await validateExportPhase(ahFiltered.pagedElectionProceeded, ahApi, network);
+
+  logger.info(
+    `✅ Export phase: ${ahFiltered.pagedElectionProceeded.length} PagedElectionProceeded events`,
+  );
+
+  // Step 6: Validate validator set propagation
+  validateValidatorSetPropagation(
+    rcFiltered.validatorSetReceived,
+    ahFiltered.pagedElectionProceeded,
+  );
+
+  logger.info(`✅ Validator set propagation: AH exported, RC received`);
+
+  // Step 7: Validate session queuing on RC
+  validateSessionQueuing(
+    rcFiltered.sessionNewSession,
+    rcFiltered.validatorSetReceived,
+  );
+
+  logger.info(`✅ Session queuing: NewSession on RC`);
+
+  // Step 8: Validate activation timestamp on AH
+  validateActivationTimestamp(ahFiltered.sessionReportReceived);
+
+  logger.info(`✅ Activation timestamp received on AH`);
+
+  // Step 9: Validate EraPaid
+  validateEraPaid(ahFiltered.eraPaid, activeEra);
+
+  const eraPaidEvent = ahFiltered.eraPaid[0];
+  logger.info(
+    `✅ EraPaid: era ${eraPaidEvent.data.eraIndex}, payout ${eraPaidEvent.data.validatorPayout}`,
+  );
+
+  // Step 10: Validate final SessionRotated
+  validateFinalSessionRotated(ahFiltered.sessionRotated, plannedEra);
+
+  logger.info(`✅ Final SessionRotated: active_era=${plannedEra}`);
+
+  logValidationSummary(phaseTransitions, ahFiltered, network, storedPageCount);
+}
+
+export const eraEventsTest: MigrationTest = {
+  name: "era_events_validation",
+
+  pre_check: async (context: PreCheckContext): Promise<PreCheckResult> => {
+    const { rc_api_before, ah_api_before } = context;
+
+    logger.info(
+      "Era events test: Loading archive mode snapshots and finding era start...",
+    );
+
+    // Find era start by searching backwards through archive
+    const rc_start_block = await findEraStartBlock(rc_api_before, "RC");
+    const ah_start_block = await findEraStartBlock(ah_api_before, "AH");
+
+    // Get end blocks (current position in archive snapshots)
+    const rc_end_block = await getBlockNumber(rc_api_before);
+    const ah_end_block = await getBlockNumber(ah_api_before);
+
+    const rc_current_era = await getCurrentEra(rc_api_before);
+    const ah_current_era = await getCurrentEra(ah_api_before);
+
+    logger.info(
+      `RC: era ${rc_current_era}, blocks ${rc_start_block} → ${rc_end_block}`,
+    );
+    logger.info(
+      `AH: era ${ah_current_era}, blocks ${ah_start_block} → ${ah_end_block}`,
+    );
+
+    return {
+      rc_pre_payload: {
+        start_block: rc_start_block,
+        end_block: rc_end_block,
+        current_era: rc_current_era,
+      },
+      ah_pre_payload: {
+        start_block: ah_start_block,
+        end_block: ah_end_block,
+        current_era: ah_current_era,
+      },
+    };
+  },
+
+  post_check: async (
+    context: PostCheckContext,
+    pre_payload: PreCheckResult,
+  ): Promise<void> => {
+    const { rc_api_after, ah_api_after } = context;
+
+    logger.info("Era events test: collecting era END state...");
+
+    // Collect all events from ERA START to ERA END
+    const rc_end_block = await getBlockNumber(rc_api_after);
+    const ah_end_block = await getBlockNumber(ah_api_after);
+
+    logger.info(`RC era end: block ${rc_end_block}`);
+    logger.info(`AH era end: block ${ah_end_block}`);
+
+    const rc_events = await collectEventsBetween(
+      rc_api_after,
+      pre_payload.rc_pre_payload.start_block,
+      pre_payload.rc_pre_payload.end_block,
+    );
+
+    const ah_events = await collectEventsBetween(
+      ah_api_after,
+      pre_payload.ah_pre_payload.start_block,
+      pre_payload.ah_pre_payload.end_block,
+    );
+
+    // Determine network from runtime
+    const network = await detectNetwork(ah_api_after);
+    logger.info(`Detected network: ${network}`);
+
+    // Run enhanced validation with runtime config queries
+    await validateEraEventSequence(
+      rc_events,
+      ah_events,
+      pre_payload,
+      ah_api_after,
+      network,
+    );
+
+    logger.info("✅ Era events test completed successfully");
+  },
+};

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "find-rc-block-bite": "node dist/zombie-bite-scripts/find_rc_block_bite.js",
     "make-new-snapshot": "node dist/zombie-bite-scripts/make_new_snapshot.js",
     "ahm": "node dist/zombie-bite-scripts/orchestrator.js",
+    "era-events-test": "node dist/zombie-bite-scripts/run_era_events_test.js",
     "prettier": "prettier --write .",
     "clean": "rm -rf dist",
     "postinstall": "papi"

--- a/zombie-bite-scripts/run_era_events_test.ts
+++ b/zombie-bite-scripts/run_era_events_test.ts
@@ -1,0 +1,90 @@
+import { runEraEventsTest } from "../migration-tests/era-events-runner.js";
+import { logger } from "../shared/logger.js";
+
+/**
+ * CLI runner for era events test
+ *
+ * This test expects zombie-bite spawn to be already running.
+ *
+ * Usage:
+ *   node dist/zombie-bite-scripts/run_era_events_test.js <base_path> [network]
+ *
+ * The test will:
+ * 1. Read ports from ports.json
+ * 2. Connect to running RC and AH nodes via WebSocket
+ * 3. Find era start by searching backwards through block history
+ * 4. Validate all staking events from era start to era end
+ */
+
+type Network = "kusama" | "polkadot";
+
+function parseNetwork(networkArg: string): Network {
+  if (networkArg === "kusama" || networkArg === "polkadot") {
+    return networkArg;
+  }
+
+  throw new Error(
+    `Invalid network: ${networkArg}. Must be either 'kusama' or 'polkadot'`,
+  );
+}
+
+function printHelp() {
+  console.log(`
+Era Events Test Runner (Zombie-Bite Spawn Mode)
+
+Prerequisites:
+  - Zombie-bite must be running with extracted databases
+
+Usage:
+  node dist/zombie-bite-scripts/run_era_events_test.js <base_path> [network]
+
+Arguments:
+  base_path        - Directory containing ports.json from zombie-bite spawn
+  network          - Network name: kusama or polkadot (default: kusama)
+
+How it works:
+  1. Reads ports.json to find RC (alice) and AH (collator) ports
+  2. Connects to running nodes via WebSocket
+  3. Searches backwards through block history to find era START
+  4. Collects and validates all staking events from era START to era END
+  5. Verifies complete election cycle (Snapshot → Signed → Validation → Export → Off)
+`);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+    printHelp();
+    process.exit(0);
+  }
+
+  const basePath = args[0];
+  const network = args[1] ? parseNetwork(args[1]) : "kusama";
+
+  if (!basePath) {
+    logger.error("Usage: node run_era_events_test.js <base_path> [network]");
+    logger.error(
+      "Example: node run_era_events_test.js ./kusama-post-migration-db-582592c0148bd2c1a5910ceaaa29633bd3ec4f4b kusama",
+    );
+    process.exit(1);
+  }
+
+  logger.info("Era Events Test Runner (Zombie-Bite Spawn Mode)", {
+    basePath,
+    network,
+  });
+
+  try {
+    const success = await runEraEventsTest(basePath, network);
+    process.exit(success ? 0 : 1);
+  } catch (error: any) {
+    logger.error("Error:", error.message || error);
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  logger.error("Unexpected error:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
Create a TS test validating all events occurring during a whole staking era, using 2 archive-mode databases (one for RC, one for AH) provided as input.
The archive needs to accommodate at least an era and  must be taken at the end of a given era to allow to inspect all events occurred during it.