### PR TITLE
Improved zombie-bite termination logic

### DIFF
--- a/zombie-bite-scripts/make_new_snapshot.ts
+++ b/zombie-bite-scripts/make_new_snapshot.ts
@@ -27,13 +27,10 @@ async function main() {
   const wsProvider = new WsProvider(`ws://127.0.0.1:${ahPort}`);
   const api = await ApiPromise.create({ provider: wsProvider });
 
-  // Get initial era
-  const currentEra = await api.query.staking.currentEra();
-  const startingEra = currentEra.unwrap().toNumber();
-
-  console.log(`⏳ Waiting until CurrentEra == ActiveEra + 1`);
 
   let wantActiveEra = -1;
+  console.log(`⏳ Waiting until CurrentEra == ActiveEra + 1`);
+
   // Subscribe to new blocks
   const unsub = await api.rpc.chain.subscribeNewHeads(async () => {
 


### PR DESCRIPTION
Script assumes that you already started a network with `just zb spawn <base_dir> post` and then:
- waits for `CurrentEra = N+1 /  ActiveEra = N` -- that's where test starts and `block` is being logged,
- waits for `CurrentEra = N+1 /  ActiveEra = N+1` and creates `stop.txt` file in `<base_dir>` which saves zombie-bite state into the `post` folder and stops the current network

To resurrect the network use newly added `after` step: `just zb spawn <base_dir> after`. 
_Note:_ Make sure you have `zombie-bite 0.2.19` or above; use `just install-zombie-bite` to update