### PR TITLE
Treasury payouts post migration

### DIFF
--- a/justfiles/ahm.justfile
+++ b/justfiles/ahm.justfile
@@ -154,4 +154,4 @@ treasury-payouts network="Polkadot":
 
 
     just ahm _npm-build
-    node dist/migration-tests/treasury_payout/run_treasury_payouts.ts {{ network }}
+    node dist/migration-tests/treasury_payout/run_treasury_payouts.js {{ network }}

--- a/justfiles/ahm.justfile
+++ b/justfiles/ahm.justfile
@@ -158,4 +158,4 @@ treasury-payouts network="Polkadot":
     fi
 
     just ahm _npm-build
-    node dist/migration-tests/treasury_payout/run_treasury_payouts.js {{ network }}
+    node dist/migration-tests/treasury_payout/run_treasury_payouts.ts {{ network }}

--- a/justfiles/ahm.justfile
+++ b/justfiles/ahm.justfile
@@ -150,7 +150,7 @@ rust-test runtime base_path:
 # Run treasury payout tests for a given network
 treasury-payouts network="Polkadot":
     #!/usr/bin/env bash
-    set -ex
+    set -euxo pipefail
 
     if [[ "{{ network }}" != "Kusama" && "{{ network }}" != "Polkadot" ]]; then
         echo "Error: network must be one of: Kusama, Polkadot"

--- a/justfiles/ahm.justfile
+++ b/justfiles/ahm.justfile
@@ -152,10 +152,6 @@ treasury-payouts network="Polkadot":
     #!/usr/bin/env bash
     set -euxo pipefail
 
-    if [[ "{{ network }}" != "Kusama" && "{{ network }}" != "Polkadot" ]]; then
-        echo "Error: network must be one of: Kusama, Polkadot"
-        exit 1
-    fi
 
     just ahm _npm-build
     node dist/migration-tests/treasury_payout/run_treasury_payouts.ts {{ network }}

--- a/justfiles/ahm.justfile
+++ b/justfiles/ahm.justfile
@@ -148,12 +148,12 @@ rust-test runtime base_path:
       post_migration_checks_only -- --include-ignored --nocapture --test-threads 1
 
 # Run treasury payout tests for a given network
-treasury-payouts network="polkadot":
+treasury-payouts network="Polkadot":
     #!/usr/bin/env bash
     set -ex
 
-    if [[ "{{ network }}" != "kusama" && "{{ network }}" != "polkadot" ]]; then
-        echo "Error: network must be one of: kusama, polkadot"
+    if [[ "{{ network }}" != "Kusama" && "{{ network }}" != "Polkadot" ]]; then
+        echo "Error: network must be one of: Kusama, Polkadot"
         exit 1
     fi
 

--- a/justfiles/ahm.justfile
+++ b/justfiles/ahm.justfile
@@ -146,3 +146,16 @@ rust-test runtime base_path:
       --features {{ runtime }}-ahm \
       --features try-runtime \
       post_migration_checks_only -- --include-ignored --nocapture --test-threads 1
+
+# Run treasury payout tests for a given network
+treasury-payouts network="polkadot":
+    #!/usr/bin/env bash
+    set -ex
+
+    if [[ "{{ network }}" != "kusama" && "{{ network }}" != "polkadot" ]]; then
+        echo "Error: network must be one of: kusama, polkadot"
+        exit 1
+    fi
+
+    just ahm _npm-build
+    node dist/migration-tests/treasury_payout/run_treasury_payouts.js {{ network }}

--- a/migration-tests/treasury_payout/run_treasury_payouts.ts
+++ b/migration-tests/treasury_payout/run_treasury_payouts.ts
@@ -2,7 +2,7 @@ import { runTreasuryPayoutTests } from './treasury_payouts.js';
 import { logger } from '../../shared/logger.js';
 
 const main = async () => {
-    const network = process.argv[2] || 'kusama';
+    const network = process.argv[2] || 'polkadot';
     
     if (network !== 'kusama' && network !== 'polkadot') {
         logger.error('Invalid network. Please specify "kusama" or "polkadot"');

--- a/migration-tests/treasury_payout/run_treasury_payouts.ts
+++ b/migration-tests/treasury_payout/run_treasury_payouts.ts
@@ -2,15 +2,15 @@ import { runTreasuryPayoutTests } from './treasury_payouts.js';
 import { logger } from '../../shared/logger.js';
 
 const main = async () => {
-    const network = process.argv[2] || 'polkadot';
+    const network = process.argv[2] || 'Polkadot';
     
-    if (network !== 'kusama' && network !== 'polkadot') {
-        logger.error('Invalid network. Please specify "kusama" or "polkadot"');
+    if (network !== 'Kusama' && network !== 'Polkadot') {
+        logger.error('Invalid network. Please specify "Kusama" or "Polkadot"');
         process.exit(1);
     }
     
     try {
-        await runTreasuryPayoutTests(network as 'kusama' | 'polkadot');
+        await runTreasuryPayoutTests(network as 'Kusama' | 'Polkadot');
         process.exit(0);
     } catch (error) {
         logger.error('❌ Tests failed:', error);

--- a/migration-tests/treasury_payout/run_treasury_payouts.ts
+++ b/migration-tests/treasury_payout/run_treasury_payouts.ts
@@ -1,0 +1,24 @@
+import { runTreasuryPayoutTests } from './treasury_payouts.js';
+import { logger } from '../../shared/logger.js';
+
+const main = async () => {
+    const network = process.argv[2] || 'kusama';
+    
+    if (network !== 'kusama' && network !== 'polkadot') {
+        logger.error('Invalid network. Please specify "kusama" or "polkadot"');
+        process.exit(1);
+    }
+    
+    try {
+        await runTreasuryPayoutTests(network as 'kusama' | 'polkadot');
+        process.exit(0);
+    } catch (error) {
+        logger.error('❌ Tests failed:', error);
+        process.exit(1);
+    }
+};
+
+main().catch((error) => {
+    logger.error('Unexpected error:', error);
+    process.exit(1);
+});

--- a/migration-tests/treasury_payout/treasury_payouts.ts
+++ b/migration-tests/treasury_payout/treasury_payouts.ts
@@ -214,7 +214,32 @@ const extractAssetType = (assetKindJson: any): { assetId: number | null; isNativ
     return { assetId, isNativeAsset }
 }
 
-
+/**
+ * Get the beneficiary balance based on asset type
+ * @param assetHub - The Asset Hub API instance
+ * @param beneficiaryAddress - The beneficiary's address
+ * @param isNativeAsset - Whether the asset is native
+ * @param assetId - The asset ID if it's a foreign asset, null otherwise
+ * @returns The beneficiary's balance as bigint
+ */
+const getBeneficiaryBalance = async (
+    assetHub: any,
+    beneficiaryAddress: string | null,
+    isNativeAsset: boolean,
+    assetId: number | null
+): Promise<bigint> => {
+    if (isNativeAsset) {
+        const beneficiaryBalance = await assetHub.api.query.system.account(beneficiaryAddress)
+        return beneficiaryBalance.data.free.toBigInt()
+    } else if (assetId !== null) {
+        const assetBalance = await assetHub.api.query.assets.account(assetId, beneficiaryAddress)
+        return assetBalance.isSome ? assetBalance.unwrap().balance.toBigInt() : 0n
+    } else {
+        // Fallback to native balance if we can't determine asset type
+        const beneficiaryBalance = await assetHub.api.query.system.account(beneficiaryAddress)
+        return beneficiaryBalance.data.free.toBigInt()
+    }
+}
 
 const polkadot = () => {
     return {

--- a/migration-tests/treasury_payout/treasury_payouts.ts
+++ b/migration-tests/treasury_payout/treasury_payouts.ts
@@ -39,8 +39,8 @@ async function testTreasuryPayouts(networkName: 'Kusama' | 'Polkadot', config: N
     });
 
     const relayChain = networkName === 'Kusama' 
-        ? (networks as any).kusama 
-        : (networks as any).polkadot;
+        ? (networks as any).Kusama 
+        : (networks as any).Polkadot;
     const assetHub = networkName === 'Kusama' 
         ? (networks as any).assetHubKusama 
         : (networks as any).assetHubPolkadot;

--- a/migration-tests/treasury_payout/treasury_payouts.ts
+++ b/migration-tests/treasury_payout/treasury_payouts.ts
@@ -187,6 +187,33 @@ const extractBeneficiaryAddress = (spendDataUnwrapped: any, spendIndex: number):
     return beneficiaryAddress;
 }
 
+/**
+ * Extract asset type information from asset kind JSON
+ * @param assetKindJson - The asset kind JSON object from spend data
+ * @returns An object containing assetId (number | null) and isNativeAsset (boolean)
+ */
+const extractAssetType = (assetKindJson: any): { assetId: number | null; isNativeAsset: boolean } => {
+    let assetId: number | null = null
+    let isNativeAsset = false
+
+    // Check if it's a foreign asset (has palletInstance 50 and generalIndex)
+    if (assetKindJson.v5?.assetId?.interior?.x2) {
+        const x2 = assetKindJson.v5.assetId.interior.x2
+        if (x2[0]?.palletInstance === 50 && x2[1]?.generalIndex) {
+            assetId = x2[1].generalIndex
+            isNativeAsset = false
+        }
+    } else if (assetKindJson.v5?.assetId?.parents === 1 && assetKindJson.v5?.assetId?.interior?.here === null) {
+        // Native asset (relay chain native asset, parents: 1 means relay chain)
+        isNativeAsset = true
+    } else if (assetKindJson.v5?.assetId?.parents === 0 && assetKindJson.v5?.assetId?.interior?.here === null) {
+        // Local native asset
+        isNativeAsset = true
+    }
+
+    return { assetId, isNativeAsset }
+}
+
 
 
 const polkadot = () => {

--- a/migration-tests/treasury_payout/treasury_payouts.ts
+++ b/migration-tests/treasury_payout/treasury_payouts.ts
@@ -47,7 +47,7 @@ async function testTreasuryPayouts(networkName: 'Kusama' | 'Polkadot', config: N
 
     try {
         // Fund Alice account for transaction fees
-        const aliceAddress = '15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5';
+        const aliceAddress = alicePair.address;
         const fundingAmount = 1000e10; 
                 
         await assetHub.dev.setStorage({

--- a/migration-tests/treasury_payout/treasury_payouts.ts
+++ b/migration-tests/treasury_payout/treasury_payouts.ts
@@ -176,6 +176,21 @@ async function testTreasuryPayouts(networkName: 'Kusama' | 'Polkadot', config: N
                 });
                 assert(spendProcessedEvent, `SpendProcessed event is not found for spend ${spendIndex} Event: ${eventsAfterCheckStatus.map((record: any) => record.event.toHuman()).join(', ')}`);
                 assert(assetHub.api.events.treasury.SpendProcessed.is(spendProcessedEvent.event), `SpendProcessed event is not found for spend ${spendIndex} Event: ${spendProcessedEvent.event.toHuman()}`);
+
+                // Get beneficiary balance after payout based on asset type
+                const beneficiaryBalanceAfterValue = await getBeneficiaryBalance(
+                    assetHub,
+                    beneficiaryAddress,
+                    isNativeAsset,
+                    assetId
+                )
+                
+                // ensure the diff of beneficiary balance after payout and before payout is equal to the spend amount
+                assert(beneficiaryBalanceAfterValue - beneficiaryBalanceBefore === spendAmount, 
+                    `The diff of beneficiary balance after payout and before payout is not equal to the spend amount. 
+                    Beneficiary balance before payout: ${beneficiaryBalanceBefore}, Spend amount: ${spendAmount}, 
+                    Beneficiary balance after payout: ${beneficiaryBalanceAfterValue}, 
+                    Diff: ${beneficiaryBalanceAfterValue - beneficiaryBalanceBefore}`);
             } catch (error) {
                 logger.error(`❌ Failed to execute payout for spend ${spendIndex}:`, error);
                 continue; // continue with next spend

--- a/migration-tests/treasury_payout/treasury_payouts.ts
+++ b/migration-tests/treasury_payout/treasury_payouts.ts
@@ -1,0 +1,187 @@
+import '@polkadot/api-augment';
+import '@polkadot/types-augment';
+import { sendTransaction, setupNetworks } from '@acala-network/chopsticks-testing';
+import { Keyring } from '@polkadot/api';
+import { cryptoWaitReady } from '@polkadot/util-crypto';
+import { logger } from '../../shared/logger.js';
+import assert from 'assert';
+
+// Wait for crypto to be ready before creating Keyring
+await cryptoWaitReady();
+const keyring = new Keyring({ type: 'sr25519' });
+const alicePair = keyring.addFromUri('//Alice');
+
+export interface NetworkConfig {
+    relayEndpoint: string;
+    relayPort: number;
+    assetHubEndpoint: string;
+    assetHubPort: number;
+}
+
+
+/**
+ * @param networkName - 'kusama' or 'polkadot'
+ * @param config - Network configuration with endpoints and ports
+ */
+async function testTreasuryPayouts(networkName: 'kusama' | 'polkadot', config: NetworkConfig): Promise<void> {
+    logger.debug(`Starting treasury payouts test on forked ${networkName} network`);
+    
+    // Setup networks based on configuration
+    const networks = await setupNetworks({
+        [networkName]: {
+            endpoint: config.relayEndpoint,
+            port: config.relayPort,
+        },
+        [networkName === 'kusama' ? 'assetHubKusama' : 'assetHubPolkadot']: {
+            endpoint: config.assetHubEndpoint,
+            port: config.assetHubPort,
+        },
+    });
+
+    const relayChain = networkName === 'kusama' 
+        ? (networks as any).kusama 
+        : (networks as any).polkadot;
+    const assetHub = networkName === 'kusama' 
+        ? (networks as any).assetHubKusama 
+        : (networks as any).assetHubPolkadot;
+
+    try {
+        // Fund Alice account for transaction fees
+        const aliceAddress = '15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5';
+        const fundingAmount = 1000e10; 
+                
+        await assetHub.dev.setStorage({
+            System: {
+                account: [
+                    [
+                        [aliceAddress], 
+                        { 
+                            providers: 1, 
+                            data: { 
+                                free: fundingAmount 
+                            } 
+                        }
+                    ]
+                ]
+            }
+        });
+        
+        logger.debug('✅ Alice account funded successfully');
+
+        // Get all spends from Asset Hub
+        const spends = await assetHub.api.query.treasury.spends.entries();
+        logger.debug(`Found ${spends.length} total spends`);
+
+        // Get current relay chain block number
+        const currentRelayChainBlockNumber = (await relayChain.api.query.system.number()).toNumber();
+        logger.debug(`Current relay chain block number: ${currentRelayChainBlockNumber}`);
+
+        // Filter spends which are pending or failed and are neither expired nor early payout
+        const pendingOrFailedSpends = spends.filter((spend: any) => {
+            const spendData = spend[1]?.unwrap();
+            return (
+                (spendData?.status.isPending || spendData?.status.isFailed) && // pending or failed
+                spendData?.validFrom.toNumber() < currentRelayChainBlockNumber && // not early payout
+                spendData?.expireAt.toNumber() > currentRelayChainBlockNumber // not expired
+            );
+        });
+
+        logger.debug(`Found ${pendingOrFailedSpends.length} eligible spends for payout testing`);
+
+        if (pendingOrFailedSpends.length === 0) {
+            logger.info('No eligible spends found for payout testing');
+            return;
+        }
+
+        // Test payout for each eligible spend
+        for (const spend of pendingOrFailedSpends) {
+            const spendIndex = spend[0].toHuman?.() as number;
+            
+            try {
+                // Create and sign the payout transaction
+                const payoutTx = assetHub.api.tx.treasury.payout(spendIndex);
+                await sendTransaction(payoutTx.signAsync(alicePair));
+                
+                await assetHub.api.rpc('dev_newBlock', { count: 1 });   
+                
+                // Check for Paid event
+                const events = await assetHub.api.query.system.events();
+                const paidEvent = events.find((record: any) => {
+                    const { event } = record;
+                    return event.section === 'treasury' && event.method === 'Paid';
+                });
+
+                assert(paidEvent, `Paid event is not found for spend ${spendIndex} Event: ${events.map((record: any) => record.event.toHuman()).join(', ')}`);
+                assert(assetHub.api.events.treasury.Paid.is(paidEvent.event), `Paid event is not found for spend ${spendIndex} Event: ${paidEvent.event.toHuman()}`);
+                
+                // Verify the spend status changed to attempted
+                const spendAfter = await assetHub.api.query.treasury.spends(spendIndex);
+                const spendDataAfter = spendAfter?.unwrap();
+                assert(spendDataAfter?.status.isAttempted, `Spend ${spendIndex} status is not attempted ${spendDataAfter?.status.toHuman()}`);
+                
+                // check status of the spend in the Asset Hub
+                const checkStatusTx = assetHub.api.tx.treasury.checkStatus(spendIndex);
+                await sendTransaction(checkStatusTx.signAsync(alicePair));
+
+                await assetHub.api.rpc('dev_newBlock', { count: 1 });
+
+                // check for SpendProcessed event
+                const eventsAfterCheckStatus = await assetHub.api.query.system.events();
+                const spendProcessedEvent = eventsAfterCheckStatus.find((record: any) => {
+                    const { event } = record;
+                    return event.section === 'treasury' && event.method === 'SpendProcessed';
+                });
+                assert(spendProcessedEvent, `SpendProcessed event is not found for spend ${spendIndex} Event: ${eventsAfterCheckStatus.map((record: any) => record.event.toHuman()).join(', ')}`);
+                assert(assetHub.api.events.treasury.SpendProcessed.is(spendProcessedEvent.event), `SpendProcessed event is not found for spend ${spendIndex} Event: ${spendProcessedEvent.event.toHuman()}`);
+            } catch (error) {
+                logger.error(`❌ Failed to execute payout for spend ${spendIndex}:`, error);
+                continue; // continue with next spend
+            }
+        }
+
+        logger.debug('✅ Treasury payouts test completed successfully');
+
+    } catch (error) {
+        logger.error('❌ Treasury payouts test failed:', error);
+        throw error;
+    } finally {
+        // Cleanup
+        await relayChain.teardown();
+        await assetHub.teardown();
+    }
+}
+
+
+const polkadot = () => {
+    return {
+        relayEndpoint: 'wss://polkadot-rpc.n.dwellir.com',
+        relayPort: 8008,
+        assetHubEndpoint: 'wss://asset-hub-polkadot-rpc.n.dwellir.com',
+        assetHubPort: 8009,
+    }
+}
+
+const kusama = () => {
+    return {
+        relayEndpoint: 'wss://rpc.ibp.network/kusama',
+        relayPort: 8008,
+        assetHubEndpoint: 'wss://sys.ibp.network/asset-hub-kusama',
+        assetHubPort: 8009,
+    }
+}
+// Note: The test on polkadot will work only after treasury is migrated to asset hub on polkadot.
+/**
+ * Main function to run treasury payout tests
+ * @param network - 'kusama' or 'polkadot'
+ */
+export async function runTreasuryPayoutTests(network: 'kusama' | 'polkadot'): Promise<void> {
+    try {
+        const config = network === 'kusama' ? kusama() : polkadot();
+        await testTreasuryPayouts(network, config);
+        logger.info(`✅ Treasury payout tests completed successfully for ${network}`);
+    } catch (error) {
+        logger.error(`❌ Treasury payout tests failed for ${network}:`, error);
+        throw error;
+    }
+}
+

--- a/migration-tests/treasury_payout/treasury_payouts.ts
+++ b/migration-tests/treasury_payout/treasury_payouts.ts
@@ -20,10 +20,10 @@ export interface NetworkConfig {
 
 
 /**
- * @param networkName - 'kusama' or 'polkadot'
+ * @param networkName - 'Kusama' or 'Polkadot'
  * @param config - Network configuration with endpoints and ports
  */
-async function testTreasuryPayouts(networkName: 'kusama' | 'polkadot', config: NetworkConfig): Promise<void> {
+async function testTreasuryPayouts(networkName: 'Kusama' | 'Polkadot', config: NetworkConfig): Promise<void> {
     logger.debug(`Starting treasury payouts test on forked ${networkName} network`);
     
     // Setup networks based on configuration
@@ -32,16 +32,16 @@ async function testTreasuryPayouts(networkName: 'kusama' | 'polkadot', config: N
             endpoint: config.relayEndpoint,
             port: config.relayPort,
         },
-        [networkName === 'kusama' ? 'assetHubKusama' : 'assetHubPolkadot']: {
+        [networkName === 'Kusama' ? 'assetHubKusama' : 'assetHubPolkadot']: {
             endpoint: config.assetHubEndpoint,
             port: config.assetHubPort,
         },
     });
 
-    const relayChain = networkName === 'kusama' 
+    const relayChain = networkName === 'Kusama' 
         ? (networks as any).kusama 
         : (networks as any).polkadot;
-    const assetHub = networkName === 'kusama' 
+    const assetHub = networkName === 'Kusama' 
         ? (networks as any).assetHubKusama 
         : (networks as any).assetHubPolkadot;
 
@@ -169,14 +169,14 @@ const kusama = () => {
         assetHubPort: 8009,
     }
 }
-// Note: The test on polkadot will work only after treasury is migrated to asset hub on polkadot.
+// Note: The test on Polkadot will work only after treasury is migrated to asset hub on Polkadot.
 /**
  * Main function to run treasury payout tests
- * @param network - 'kusama' or 'polkadot'
+ * @param network - 'Kusama' or 'Polkadot'
  */
-export async function runTreasuryPayoutTests(network: 'kusama' | 'polkadot'): Promise<void> {
+export async function runTreasuryPayoutTests(network: 'Kusama' | 'Polkadot'): Promise<void> {
     try {
-        const config = network === 'kusama' ? kusama() : polkadot();
+        const config = network === 'Kusama' ? kusama() : polkadot();
         await testTreasuryPayouts(network, config);
         logger.info(`✅ Treasury payout tests completed successfully for ${network}`);
     } catch (error) {

--- a/migration-tests/treasury_payout/treasury_payouts.ts
+++ b/migration-tests/treasury_payout/treasury_payouts.ts
@@ -79,11 +79,9 @@ async function testTreasuryPayouts(networkName: 'Kusama' | 'Polkadot', config: N
         // Filter spends which are pending or failed and are neither expired nor early payout
         const pendingOrFailedSpends = spends.filter((spend: any) => {
             const spendData = spend[1]?.unwrap();
-            return (
-                (spendData?.status.isPending || spendData?.status.isFailed) && // pending or failed
-                spendData?.validFrom.toNumber() < currentRelayChainBlockNumber && // not early payout
-                spendData?.expireAt.toNumber() > currentRelayChainBlockNumber // not expired
-            );
+            const isSpendPendingOrFailed = spendData?.status.isPending || spendData?.status.isFailed ;
+            const isSpendNotExpired = currentRelayChainBlockNumber < spendData?.expireAt.toNumber();
+            return isSpendPendingOrFailed && isSpendNotExpired;
         });
 
         logger.debug(`Found ${pendingOrFailedSpends.length} eligible spends for payout testing`);

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "authorize-upgrade": "node dist/zombie-bite-scripts/authorize_upgrade_ah.js",
     "report-account-migration-status": "node dist/zombie-bite-scripts/report_account_migration_status.js",
     "compare-state": "node dist/migration-tests/index.js",
-    "treasury-payouts": "node dist/migration-tests/treasury_payout/run_treasury_payouts.js",
+    "treasury-payouts": "node dist/migration-tests/treasury_payout/run_treasury_payouts.ts",
     "find-rc-block-bite": "node dist/zombie-bite-scripts/find_rc_block_bite.js",
     "make-new-snapshot": "node dist/zombie-bite-scripts/make_new_snapshot.js",
     "create-migration-done-file": "node dist/zombie-bite-scripts/create_migration_done_file.js",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "authorize-upgrade": "node dist/zombie-bite-scripts/authorize_upgrade_ah.js",
     "report-account-migration-status": "node dist/zombie-bite-scripts/report_account_migration_status.js",
     "compare-state": "node dist/migration-tests/index.js",
+    "treasury-payouts": "node dist/migration-tests/treasury_payout/run_treasury_payouts.js",
     "find-rc-block-bite": "node dist/zombie-bite-scripts/find_rc_block_bite.js",
     "make-new-snapshot": "node dist/zombie-bite-scripts/make_new_snapshot.js",
     "create-migration-done-file": "node dist/zombie-bite-scripts/create_migration_done_file.js",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "authorize-upgrade": "node dist/zombie-bite-scripts/authorize_upgrade_ah.js",
     "report-account-migration-status": "node dist/zombie-bite-scripts/report_account_migration_status.js",
     "compare-state": "node dist/migration-tests/index.js",
-    "treasury-payouts": "node dist/migration-tests/treasury_payout/run_treasury_payouts.ts",
+    "treasury-payouts": "node dist/migration-tests/treasury_payout/run_treasury_payouts.js",
     "find-rc-block-bite": "node dist/zombie-bite-scripts/find_rc_block_bite.js",
     "make-new-snapshot": "node dist/zombie-bite-scripts/make_new_snapshot.js",
     "create-migration-done-file": "node dist/zombie-bite-scripts/create_migration_done_file.js",


### PR DESCRIPTION
Check treasury payouts which are already approved can be paid out post-migration

I have tested it locally for Kusama, the treasury payout call is working and the spend is getting processed.

It is kept in a separate directory as this test need to call an extrinsic and therefore need a locally forked network to modify it, compared to other tests that are only calling the rpc end point for fetching the storage data.

I have tested it on post migration snapshot from ci run [Links](https://github.com/paritytech/ahm-dryrun/actions/runs/18856970433) , it was working on PAH as well.